### PR TITLE
add onfail function as param to webgazer.begin

### DIFF
--- a/src/webgazer.js
+++ b/src/webgazer.js
@@ -320,9 +320,12 @@
 
     /**
      * starts all state related to webgazer -> dataLoop, video collection, click listener
+     * If starting fails, call `onFail` param function.
      */
-    webgazer.begin = function() {
+    webgazer.begin = function(onFail) {
         loadGlobalData();
+
+        onFail = onFail || function() {console.log("No stream")};
 
         if (debugVideoLoc) {
             init(debugVideoLoc);
@@ -343,7 +346,7 @@
                         init(window.URL.createObjectURL(stream));
                     },
                     function(e){
-                        console.log("No stream");
+                        onFail();
                         videoElement = null;
                     });
         }


### PR DESCRIPTION
TL;DR: Add `onFail` function as parameter to `webgazer.begin` so that WebGazer users have some control over what happens if WebGazer doesn't start.

Integrating WebGazer with code.pyret.org, we wanted to give users some time to learn about why their webcam was being used rather than immediately having their browser pop up an "Allow access to webcam" message. Then, they would have the choice of allowing us or denying us access. This choice is persistent-- we want to avoid annoying users by asking them multiple times.

However, this can lead to a problem. What if the user clicks that they will allow us access, but denies access from their browser? In this case we want to remind them to allow us access from the browser. This is where the `onFail` parameter comes in.

To me, this is better than querying some state data of whether WebGazer started successfully, especially if WebGazer is started asynchronously.