### PR TITLE
add name and version to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "webgazer",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/brownhci/WebGazer.git"


### PR DESCRIPTION
I saw that you had done work on package.json; I wanted to see if I could include WebGazer from brownhci rather than my own copy. That didn't work, but it did after I addied in `name` and `version` fields!

Thank you so much for creating the package.json. I'm happy to know that it's being updated with the cool new build system.