### PR TITLE
Add python version of build script

### DIFF
--- a/build/build_library.py
+++ b/build/build_library.py
@@ -1,0 +1,12 @@
+outfileName = 'webgazer.js'
+listfileName = 'toCombine'
+
+with open(listfileName) as f:
+    filenames = f.readlines()
+filenames = [x.strip() for x in filenames]
+
+with open(outfileName, 'w') as outfile:
+    for fname in filenames:
+        with open(fname) as infile:
+            outfile.write(infile.read())
+            outfile.write('\n')


### PR DESCRIPTION
When I tried to run the `build_library` script on Git Bash on Windows it didn't work because of `\r` attached to the file names in `toCombine`. As a quick fix I added a python script to substitute the bash build script.
