### PR TITLE
Fix getPupils (and therefore LinearReg)

### DIFF
--- a/src/pupil.js
+++ b/src/pupil.js
@@ -2,7 +2,7 @@
 
     window.webgazer = window.webgazer || {};
     webgazer.pupil = webgazer.pupil || {};
-    
+
     /**
      * Returns intensity value at x,y position of a pixels image
      * @param {Array} pixels - array of size width*height
@@ -14,7 +14,7 @@
     var getValue = function (pixels, x, y, width){
         return pixels[y * width + x];
     };
-    
+
     /**
      * Computes summation area table/integral image of a pixel matrix
      * @param {Array} pixels value of eye area
@@ -26,18 +26,18 @@
         var integralImage = new Array(width);
         var sumx = 0;
         var sumy = 0;
-    
+
         for (var i = 0; i < width; i++){
             integralImage[i] = new Array(height);
             sumx += getValue(pixels, i, 0, width);
             integralImage[i][0] = sumx;
         }
-    
+
         for (var i = 0; i < height; i++){
             sumy += getValue(pixels, 0, i, width);
             integralImage[0][i] = sumy;
         }
-    
+
         for (var x = 1; x < width; x++){
             for (var y = 1; y < height; y++){
                 integralImage[x][y] = getValue(pixels, x, y, width) + integralImage[x - 1][y] + integralImage[x][y - 1] - integralImage[x - 1][y - 1];
@@ -45,7 +45,7 @@
         }
         return integralImage;
     };
-    
+
     /**
      * Detects a pupil in a set of pixels
      * @param  {Array} pixels - patch of pixels to look for pupil into
@@ -64,13 +64,13 @@
             //think of a sliding rectangular window of width halfWidth*2 that goes through the whole eye pixel matrix and does the following:
             //1) computes the irisArea, which is the total intensity of the iris
             //2) computes the scleraIrisArea, which is multiple rows of pixels including the sclera and iris.
-            //3) computes avg, which is the intensity of the area divided by the number of pixels.               
+            //3) computes avg, which is the intensity of the area divided by the number of pixels.
             //start at the bottom right of the rectangle!not top left
             for (var x = halfWidth; x < width - offset; x++){
                 for (var y = halfWidth; y < height - offset; y++){
                     //evaluate area by the formula found on wikipedia about the summed area table: I(D)+I(A)-I(B)-I(C)
                     var irisArea = summedAreaTable[x + offset][y + offset] + summedAreaTable[x + offset - halfWidth][y + offset - halfWidth] - summedAreaTable[x + offset][y + offset - halfWidth] - summedAreaTable[x + offset - halfWidth][y + offset];
-                    var avgScore = 1.0 * irisArea / ((halfWidth + 1) * (halfWidth + 1)) + 1; 
+                    var avgScore = 1.0 * irisArea / ((halfWidth + 1) * (halfWidth + 1)) + 1;
                     //summation area table again
                     var scleraIrisArea = ((1.0 * summedAreaTable[width - 1 - offset][y + offset] + summedAreaTable[0 + offset][y + offset - halfWidth] - summedAreaTable[0 + offset][y + offset] - summedAreaTable[width - 1 - offset][y + offset - halfWidth]) - irisArea);
                     //minimize avgScore/scleraIrisArea. 150 is too high, might have to change since it's closer to white
@@ -84,7 +84,7 @@
         }
         return [bestPoint, bestHalfWidth];
     };
-    
+
     /**
      * Given an object with two eye patches it finds the location of the detected pupils
      * @param  {Object} eyesObj - left and right detected eye patches
@@ -95,16 +95,16 @@
             return eyesObj;
         }
         if (!eyesObj.left.blink) {
-            eyesObj.left.pupil = getSinglePupil(Array.prototype.slice.call(webgazer.util.grayscale(eyesObj.left.patch, eyesObj.left.width, eyesObj.left.height)), eyesObj.left.width, eyesObj.left.height);
+            eyesObj.left.pupil = getSinglePupil(Array.prototype.slice.call(webgazer.util.grayscale(eyesObj.left.patch.data, eyesObj.left.width, eyesObj.left.height)), eyesObj.left.width, eyesObj.left.height);
             eyesObj.left.pupil[0][0] -= eyesObj.left.pupil[1];
             eyesObj.left.pupil[0][1] -= eyesObj.left.pupil[1];
         }
         if (!eyesObj.right.blink) {
-            eyesObj.right.pupil = getSinglePupil(Array.prototype.slice.call(webgazer.util.grayscale(eyesObj.right.patch, eyesObj.right.width, eyesObj.right.height)), eyesObj.right.width, eyesObj.right.height);
+            eyesObj.right.pupil = getSinglePupil(Array.prototype.slice.call(webgazer.util.grayscale(eyesObj.right.patch.data, eyesObj.right.width, eyesObj.right.height)), eyesObj.right.width, eyesObj.right.height);
             eyesObj.right.pupil[0][0] -= eyesObj.right.pupil[1];
             eyesObj.right.pupil[0][1] -= eyesObj.right.pupil[1];
         }
         return eyesObj;
     }
-        
+
 }(window));

--- a/src/util.js
+++ b/src/util.js
@@ -3,7 +3,7 @@
     self.webgazer = self.webgazer || {};
     self.webgazer.util = self.webgazer.util || {};
     self.webgazer.mat = self.webgazer.mat || {};
-    
+
     /**
      * Eye class, represents an eye patch detected in the video stream
      * @param {ImageData} patch - the image data corresponding to an eye
@@ -19,8 +19,8 @@
         this.width = width;
         this.height = height;
     };
-    
-    
+
+
     //Data Window class
     //operates like an array but 'wraps' data around to keep the array at a fixed windowSize
     /**
@@ -94,10 +94,10 @@
     //Helper functions
     /**
      * Grayscales an image patch. Can be used for the whole canvas, detected face, detected eye, etc.
-     * @param  {ImageData} imageData - image data to be grayscaled
+     * @param  {Array} imageData - image data to be grayscaled
      * @param  {Number} imageWidth  - width of image data to be grayscaled
      * @param  {Number} imageHeight - height of image data to be grayscaled
-     * @return {ImageData} grayscaledImage
+     * @return {Array} grayscaledImage
      */
     self.webgazer.util.grayscale = function(imageData, imageWidth, imageHeight){
         //TODO implement ourselves to remove dependency
@@ -106,7 +106,7 @@
 
     /**
      * Increase contrast of an image
-     * @param {ImageData} grayscaleImageSrc - grayscale integer array
+     * @param {Array} grayscaleImageSrc - grayscale integer array
      * @param {Number} step - sampling rate, control performance
      * @param {Array} destinationImage - array to hold the resulting image
      */
@@ -140,7 +140,7 @@
 
         return tempCanvas.getContext('2d').getImageData(0, 0, resizeWidth, resizeHeight);
     };
-    
+
     /**
      * Checks if the prediction is within the boundaries of the viewport and constrains it
      * @param  {Array} prediction [x,y] - predicted gaze coordinates
@@ -275,7 +275,7 @@
         this.P = P_initial; //Initial covariance matrix
         this.X = X_initial; //Initial guess of measurement
     };
-    
+
     /**
      * Get Kalman next filtered value and update the internal state
      * @param {Array} z - the new measurement


### PR DESCRIPTION
`webgazer.pupil.getPupils` was passing an `ImageData` to `webgazer.util.grayscale`, which caused it to return an empty result. Instead, the method should take an `Array`, which we can get by calling `.data` in the `ImageData`.

Also cleaned up some trailing whitespace.