### PR TITLE
Prevent WebGazer from crashing if localStorage is full

### DIFF
--- a/build/webgazer.js
+++ b/build/webgazer.js
@@ -10212,7 +10212,12 @@ if (typeof exports !== 'undefined') {
             'settings': settings,
             'data': regs[0].getData() || data
         };
-        window.localStorage.setItem(localstorageLabel, JSON.stringify(storage));
+        try {
+        	window.localStorage.setItem(localstorageLabel, JSON.stringify(storage));
+        } catch(e) {
+        	console.error(e)
+        }
+        
         //TODO data should probably be stored in webgazer object instead of each regression model
         //     -> requires duplication of data, but is likely easier on regression model implementors
     }


### PR DESCRIPTION
Add a try catch to setGlobalData function on window.localStorage.setItem to prevent WebGazer from crashing if you try to save data larger than what localStorage can allow.