### PR TITLE
Fix Calibration Reference Exception

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,7 @@ module.exports = function(grunt) {
 					'src/ridgeRegThreaded.js',
 					'src/util.js',
 					'src/webgazer.js',
+					'js/draw_plotted_points.js',
 				],
 				dest: './build/webgazer.js',
 			}

--- a/index.html
+++ b/index.html
@@ -14,7 +14,6 @@ Instructions on use can be found in the README repository.
         <META HTTP-EQUIV="CONTENT-TYPE" CONTENT="text/html; charset=utf-8">
         <TITLE>WebGazer Demo</TITLE>
         <link rel="stylesheet" type="text/css" href="./css/style.css">
-        <link rel="stylesheet" type="text/css" href="./node_modules/sweetalert/dist/sweetalert.css"> 
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
     </head>
     <body LANG="en-US" LINK="#0000ff" DIR="LTR">
@@ -25,7 +24,7 @@ Instructions on use can be found in the README repository.
         <script src="./js/calibration.js"></script>
         <script src="./js/precision_calculation.js"></script>
         <script src="./js/precision_store_points.js"></script>
-        <script src="./node_modules/sweetalert/dist/sweetalert.min.js"></script> 
+        <script src="./node_modules/sweetalert/dist/sweetalert.min.js"></script>
         <nav id="webgazerNavbar" class="navbar navbar-default navbar-fixed-top">
           <div class="container-fluid">
             <div class="navbar-header">

--- a/js/calibration.js
+++ b/js/calibration.js
@@ -25,7 +25,7 @@ function PopUpInstruction(){
   }).then(isConfirm => {
     ShowCalibrationPoint();
   });
-  
+
 }
 /**
   * Show the help instructions right at the start.

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "grunt": "*",
     "grunt-contrib-concat": "*",
     "grunt-contrib-uglify-es": "git://github.com/gruntjs/grunt-contrib-uglify.git#harmony",
-    "jsdoc": "^3.5.5"
-  },
-  "dependencies": {
+    "jsdoc": "^3.5.5",
     "browser-sync": "^2.18.13",
     "git": "^0.1.5",
     "jquery": "^3.2.1",


### PR DESCRIPTION
This should fix the javascript reference exception regarding the SweetAlert CSS file (which does not exist) and adding files from toCombine correctly into the GruntFile