### PR TITLE
Switch from SweetAlert to SweetAlert2

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@ Instructions on use can be found in the README repository.
         <script src="./js/calibration.js"></script>
         <script src="./js/precision_calculation.js"></script>
         <script src="./js/precision_store_points.js"></script>
-        <script src="./node_modules/sweetalert/dist/sweetalert.min.js"></script>
+        <script src="./node_modules/sweetalert2/dist/sweetalert2.all.min.js"></script>
         <nav id="webgazerNavbar" class="navbar navbar-default navbar-fixed-top">
           <div class="container-fluid">
             <div class="navbar-header">

--- a/js/calibration.js
+++ b/js/calibration.js
@@ -18,12 +18,8 @@ function PopUpInstruction(){
   swal({
     title:"Calibration",
     text: "Please click on each of the 9 points on the screen. You must click on each point 5 times till it goes yellow. This will calibrate your eye movements.",
-    buttons:{
-      cancel: false,
-      confirm: true
-    }
-  }).then(isConfirm => {
-    ShowCalibrationPoint();
+  }).then(result => {
+    result.value && ShowCalibrationPoint();
   });
 
 }
@@ -79,10 +75,9 @@ $(document).ready(function(){
             swal({
               title: "Calculating measurement",
               text: "Please don't move your mouse & stare at the middle dot for the next 5 seconds. This will allow us to calculate the accuracy of our predictions.",
-              closeOnEsc: false,
-              allowOutsideClick: false,
-              closeModal: true
-            }).then( isConfirm => {
+              allowEscapeKey: false,
+              allowOutsideClick: false
+            }).then( () => {
 
                 // makes the variables true for 5 seconds & plots the points
                 $(document).ready(function(){
@@ -98,12 +93,10 @@ $(document).ready(function(){
                       swal({
                         title: "Your accuracy measure is " + precision_measurement + "%",
                         allowOutsideClick: false,
-                        buttons: {
-                          cancel: "Recalibrate",
-                          confirm: true,
-                        }
-                      }).then(isConfirm => {
-                          if (isConfirm){
+                        showCancelButton: true,
+                        cancelButtonText: "Recalibrate",
+                      }).then(result => {
+                          if (result.value){
                             //clear the calibration & hide the last middle button
                             ClearCanvas();
                           } else {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "browser-sync": "^2.18.13",
     "git": "^0.1.5",
     "jquery": "^3.2.1",
-    "sweetalert": "^2.1.0"
+    "sweetalert2": "^7.9.0"
   }
 }


### PR DESCRIPTION
I would like to propose to switch from SweetAlert to [SweetAlert2](https://github.com/sweetalert2/sweetalert2) - the supported fork of SweetAlert. The original reason for creating SweetAlert2 is the inactivity of SweetAlert: https://stackoverflow.com/a/27842854/1331425 

### Reasons to switch:

1. Accessibility (WAI-ARIA) - SweetAlert2 is fully WAI-ARIA compatible and supports all popular screen-readers. Accessibility is a must in 2017, there are a lot of explanatory and tech articles, but this one is truly inspirable: [Software development 450 words per minute](https://www.vincit.fi/en/blog/software-development-450-words-per-minute/)

2. Better buttons contrast is a huge advantage for all users especially for users with vision disabilities. 

SweetAlert | SweetAlert2
---|---
![](https://i.imgur.com/0n2v5IE.png) | ![](https://i.imgur.com/a0vWomi.png)

If you want to keep the original buttons order, I can easily do that by setting the `reverseButtons` parameter to `true`.

3. Better support, average time to resolve an issue:

   - SweetAlert: ![](http://isitmaintained.com/badge/resolution/t4t5/sweetalert.svg)
   - SweetAlert2: ![](http://isitmaintained.com/badge/resolution/sweetalert2/sweetalert2.svg)

5. SweetAlert2 is more popular that SweetAlert:

   - SweetAlert: ![](https://img.shields.io/npm/dm/sweetalert.svg)
   - SweetAlert2: ![](https://img.shields.io/npm/dm/sweetalert2.svg)
  