### PR TITLE
Add cache reload of webgazer in extract tool to prevent errors.

### DIFF
--- a/www/data/src/webgazerExtractClient.html
+++ b/www/data/src/webgazerExtractClient.html
@@ -57,7 +57,7 @@
     <p id="procFPS"></p>
     </div>
 
-    <script src="webgazer.js"></script>
+    <script src="webgazer.js?newversion"></script>
 
     <script>
         // Initialize variables


### PR DESCRIPTION
[Bug] If webGazerExtractClient.html hits an initial error during processing, it can lead to webgazer.js failing to process any future video. This issue has been encountered on multiple machines and browsers. Example initial errors include parsing errors or the process being killed.

[Fix] By forcing the browser cache to reload the webgazer.js resource, this bug is fixed and webGazerExtractClient.html is able to continue on other videos. This is accomplished by adding ?newversion to the end of the resource name.