### PR TITLE
Hotfix for webgazer.params.showVideoPreview + more

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -571,6 +571,8 @@ async function init(stream) {
 /**
  * Initializes navigator.mediaDevices.getUserMedia
  * depending on the browser capabilities
+ * 
+ * @return Promise 
  */
 function setUserMediaVariable(){
 
@@ -607,7 +609,7 @@ function setUserMediaVariable(){
  */
 webgazer.begin = function(onFail) {
   if (window.location.protocol !== 'https:' && window.location.hostname !== 'localhost' && window.chrome){
-    alert("WebGazer works only over https. If you are doing local development you need to run a local server.");
+    alert("WebGazer works only over https. If you are doing local development, you need to run a local server.");
   }
 
   // Load model data stored in localforage.
@@ -633,9 +635,7 @@ webgazer.begin = function(onFail) {
     let stream;
     try {
       stream = await navigator.mediaDevices.getUserMedia( webgazer.params.camConstraints );
-      if (webgazer.params.showVideoPreview) {
-        init(stream);
-      }
+      init(stream);
       resolve(webgazer);
     } catch(err) {
       onFail();
@@ -733,20 +733,35 @@ webgazer.detectCompatibility = function() {
 };
 
 /**
- * Set whether the video preview is visible or not.
+ * Set whether to show any of the video previews (camera, face overlay, feedback box).
+ * If true: visibility depends on corresponding params (default all true).
+ * If false: camera, face overlay, feedback box are all hidden
+ * @param {bool} val
+ * @return {webgazer} this
+ */
+webgazer.showVideoPreview = function(val) {
+  webgazer.params.showVideoPreview = val;
+  webgazer.showVideo(val && webgazer.params.showVideo);
+  webgazer.showFaceOverlay(val && webgazer.params.showFaceOverlay);
+  webgazer.showFaceFeedbackBox(val && webgazer.params.showFaceFeedbackBox);
+  return webgazer;
+}
+
+/**
+ * Set whether the camera video preview is visible or not (default true).
  * @param {*} bool
  * @return {webgazer} this
  */
 webgazer.showVideo = function(val) {
   webgazer.params.showVideo = val;
-  if( videoElement) {
+  if(videoElement) {
     videoElement.style.display = val ? 'block' : 'none';
   }
   return webgazer;
 };
 
 /**
- * Set whether the face overlay is visible or not.
+ * Set whether the face overlay is visible or not (default true).
  * @param {*} bool
  * @return {webgazer} this
  */
@@ -759,7 +774,7 @@ webgazer.showFaceOverlay = function(val) {
 };
 
 /**
- * Set whether the face feedback box is visible or not.
+ * Set whether the face feedback box is visible or not (default true).
  * @param {*} bool
  * @return {webgazer} this
  */
@@ -773,7 +788,8 @@ webgazer.showFaceFeedbackBox = function(val) {
 };
 
 /**
- * Set whether the gaze prediction point(s) are visible or not. Multiple because of a trail of past dots.
+ * Set whether the gaze prediction point(s) are visible or not.
+ * Multiple because of a trail of past dots. Default true
  * @return {webgazer} this
  */
 webgazer.showPredictionPoints = function(val) {
@@ -783,6 +799,15 @@ webgazer.showPredictionPoints = function(val) {
   }
   return webgazer;
 };
+
+/**
+ * Set whether a Kalman filter will be applied to gaze predictions (default true);
+ * @return {webgazer} this
+ */
+webgazer.applyKalmanFilter = function(val) {
+  webgazer.params.applyKalmanFilter = val;
+  return webgazer;
+}
 
 /**
  * Define constraints on the video camera that is used. Useful for non-standard setups.

--- a/src/params.mjs
+++ b/src/params.mjs
@@ -16,7 +16,8 @@ const params = {
   showGazeDot: true,
   camConstraints: { video: { width: { min: 320, ideal: 640, max: 1920 }, height: { min: 240, ideal: 480, max: 1080 }, facingMode: "user" } },
   dataTimestep: 50,
-  showVideoPreview: false,
+  showVideoPreview: true,
+  applyKalmanFilter: true,
   // Whether or not to store accuracy eigenValues, used by the calibration example file
   storingPoints: false,
 };

--- a/src/ridgeReg.mjs
+++ b/src/ridgeReg.mjs
@@ -215,7 +215,7 @@ reg.RidgeReg.prototype.predict = function(eyesObj) {
   predictedX = Math.floor(predictedX);
   predictedY = Math.floor(predictedY);
 
-  if (window.applyKalmanFilter) {
+  if (params.applyKalmanFilter) {
     // Update Kalman model, and get prediction
     var newGaze = [predictedX, predictedY]; // [20200607 xk] Should we use a 1x4 vector?
     newGaze = this.kalman.update(newGaze);

--- a/src/ridgeRegThreaded.mjs
+++ b/src/ridgeRegThreaded.mjs
@@ -1,5 +1,6 @@
-import util from './util';
 import numeric from 'numeric';
+import util from './util';
+import params from './params';
 
 const reg = {};
 
@@ -119,7 +120,7 @@ reg.RidgeRegThreaded.prototype.predict = function(eyesObj) {
     predictedX = Math.floor(predictedX);
     predictedY = Math.floor(predictedY);
 
-    if (window.applyKalmanFilter) {
+    if (params.applyKalmanFilter) {
         // Update Kalman model, and get prediction
         var newGaze = [predictedX, predictedY]; // [20200607 xk] Should we use a 1x4 vector?
         newGaze = this.kalman.update(newGaze);

--- a/src/ridgeWeightedReg.mjs
+++ b/src/ridgeWeightedReg.mjs
@@ -1,6 +1,7 @@
 import mat from './mat';
 import util from './util';
 import numeric from 'numeric';
+import params from './params';
 
 const reg = {};
 
@@ -99,7 +100,7 @@ reg.RidgeWeightedReg.prototype.init = function() {
 
     //sets to one second worth of cursor trail
     this.trailTime = 1000;
-    this.trailDataWindow = this.trailTime / webgazer.params.moveTickSize;
+    this.trailDataWindow = this.trailTime / params.moveTickSize;
     this.screenXTrailArray = new util.DataWindow(trailDataWindow);
     this.screenYTrailArray = new util.DataWindow(trailDataWindow);
     this.eyeFeaturesTrail = new util.DataWindow(trailDataWindow);
@@ -242,7 +243,7 @@ reg.RidgeWeightedReg.prototype.predict = function(eyesObj) {
     predictedX = Math.floor(predictedX);
     predictedY = Math.floor(predictedY);
 
-    if (window.applyKalmanFilter) {
+    if (params.applyKalmanFilter) {
         // Update Kalman model, and get prediction
         var newGaze = [predictedX, predictedY]; // [20200607 xk] Should we use a 1x4 vector?
         newGaze = this.kalman.update(newGaze);

--- a/www/calibration.html
+++ b/www/calibration.html
@@ -46,7 +46,7 @@ Instructions on use can be found in the README repository.
                 <!-- Accuracy -->
                 <li id="Accuracy"><a>Not yet Calibrated</a></li>
                 <li><a onclick="Restart()" href="#">Recalibrate</a></li>
-                <li><a onclick="window.applyKalmanFilter = !window.applyKalmanFilter" href="#">Toggle Kalman Filter</a></li>
+                <li><a onclick="webgazer.applyKalmanFilter(!webgazer.params.applyKalmanFilter)" href="#">Toggle Kalman Filter</a></li>
               </ul>
               <ul class="nav navbar-nav navbar-right">
                 <li><button class="helpBtn" data-toggle="modal" data-target="#helpModal"><a data-toggle="modal"><span class="glyphicon glyphicon-cog"></span> Help</a></li>

--- a/www/js/collision.js
+++ b/www/js/collision.js
@@ -1,6 +1,3 @@
-  // Kalman Filter defaults to on.
-  window.applyKalmanFilter = true;
-
   // Set to true if you want to save the data even if you reload the page.
   window.saveDataAcrossSessions = false;
 
@@ -16,12 +13,13 @@
         var localstorageSettingsLabel = 'webgazerGlobalSettings';
         localforage.setItem(localstorageSettingsLabel, null);
     }
-    webgazer.params.showVideoPreview = true;
     const webgazerInstance = await webgazer.setRegression('ridge') /* currently must set regression and tracker */
-    .setTracker('TFFacemesh')
-    .begin();
-    webgazerInstance.showPredictionPoints(false); /* shows a square every 100 milliseconds where current prediction is */
-    // Add the SVG component on the top of everything.
+      .setTracker('TFFacemesh')
+      .begin();
+    webgazerInstance.showVideoPreview(true) /* shows all video previews */
+      .showPredictionPoints(false) /* shows a square every 100 milliseconds where current prediction is */
+      .applyKalmanFilter(true); // Kalman Filter defaults to on.
+      // Add the SVG component on the top of everything.
     setupCollisionSystem();
     webgazer.setGazeListener( collisionEyeListener );
   };

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -8,8 +8,9 @@ window.onload = async function() {
           //   console.log(data); /* data is an object containing an x and y key which are the x and y prediction coordinates (no bounds limiting) */
           //   console.log(clock); /* elapsed time in milliseconds since webgazer.begin() was called */
         }).begin();
-        webgazer.showPredictionPoints(true); /* shows a square every 100 milliseconds where current prediction is */
-
+        webgazer.showVideoPreview(true) /* shows all video previews */
+            .showPredictionPoints(true) /* shows a square every 100 milliseconds where current prediction is */
+            .applyKalmanFilter(true); /* Kalman Filter defaults to on. Can be toggled by user. */
 
     //Set up the webgazer video feedback.
     var setup = function() {
@@ -23,9 +24,6 @@ window.onload = async function() {
     setup();
 
 };
-
-// Kalman Filter defaults to on. Can be toggled by user.
-window.applyKalmanFilter = true;
 
 // Set to true if you want to save the data even if you reload the page.
 window.saveDataAcrossSessions = true;


### PR DESCRIPTION
* Fixed `webgazer.params.showVideoPreview`. Does not need to be set to `true` for webgazer to be initialized anymore. 
  * Addresses #178 and #183 (maybe related to #165)
  * Redoing what I did in #157 -- apologies for reintroducing the bug somewhere along the way
* Added new function `webgazer.showVideoPreview(val)`.
  * `webgazer.showVideoPreview(false)` to hide webcam preview, face overlay, and face feedback box
  * `webgazer.showVideoPreview(true)` to allow `webgazer.showVideo(val)`, `webgazer.showFaceOverlay(val)`, and `webgazer.showFaceFeedbackBox(val)` settings to apply.
* Added new variable `webgazer.params.applyKalmanFilter`, which defaults to `true`. Added new function `webgazer.applyKalmanFilter(val)` to activate/deactivate Kalman filter on gaze predictions.
  * Updated demo webpages accordingly.