### PR TITLE
Nest video elements in container <div>

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -22,6 +22,7 @@ webgazer.params = params;
 
 //video elements
 var videoStream = null;
+var videoContainerElement = null;
 var videoElement = null;
 var videoElementCanvas = null;
 var faceOverlay = null;
@@ -477,15 +478,23 @@ async function init(stream) {
   // used for webgazer.stopVideo() and webgazer.setCameraConstraints()
   videoStream = stream;
 
+  // create a video element container to enable customizable placement on the page
+  videoContainerElement = document.createElement('div');
+  videoContainerElement.id = webgazer.params.videoContainerId;
+  videoContainerElement.style.display = webgazer.params.showVideo ? 'block' : 'none';
+  videoContainerElement.style.position = 'fixed';
+  videoContainerElement.style.top = topDist;
+  videoContainerElement.style.left = leftDist;
+  videoContainerElement.style.width = webgazer.params.videoViewerWidth + 'px';
+  videoContainerElement.style.height = webgazer.params.videoViewerHeight + 'px';
+  
   videoElement = document.createElement('video');
   videoElement.setAttribute('playsinline', '');
   videoElement.id = webgazer.params.videoElementId;
   videoElement.srcObject = stream;
   videoElement.autoplay = true;
   videoElement.style.display = webgazer.params.showVideo ? 'block' : 'none';
-  videoElement.style.position = 'fixed';
-  videoElement.style.top = topDist;
-  videoElement.style.left = leftDist;
+  videoElement.style.position = 'absolute';
   // We set these to stop the video appearing too large when it is added for the very first time
   videoElement.style.width = webgazer.params.videoViewerWidth + 'px';
   videoElement.style.height = webgazer.params.videoViewerHeight + 'px';
@@ -501,9 +510,7 @@ async function init(stream) {
   faceOverlay = document.createElement('canvas');
   faceOverlay.id = webgazer.params.faceOverlayId;
   faceOverlay.style.display = webgazer.params.showFaceOverlay ? 'block' : 'none';
-  faceOverlay.style.position = 'fixed';
-  faceOverlay.style.top = topDist;
-  faceOverlay.style.left = leftDist;
+  faceOverlay.style.position = 'absolute';
 
   // Mirror video feed
   if (webgazer.params.mirrorVideo) {
@@ -524,8 +531,8 @@ async function init(stream) {
   faceFeedbackBox = document.createElement('canvas');
   faceFeedbackBox.id = webgazer.params.faceFeedbackBoxId;
   faceFeedbackBox.style.display = webgazer.params.showFaceFeedbackBox ? 'block' : 'none';
-  faceFeedbackBox.style.position = 'fixed';
   faceFeedbackBox.style.border = 'solid';
+  faceFeedbackBox.style.position = 'absolute';
 
   // Gaze dot
   // Starts offscreen
@@ -543,16 +550,17 @@ async function init(stream) {
   gazeDot.style.height = '10px';
 
   // Add other preview/feedback elements to the screen once the video has shown and its parameters are initialized
-  document.body.appendChild(videoElement);
+  videoContainerElement.appendChild(videoElement);
+  document.body.appendChild(videoContainerElement);
   function setupPreviewVideo(e) {
 
     // All video preview parts have now been added, so set the size both internally and in the preview window.
     setInternalVideoBufferSizes( videoElement.videoWidth, videoElement.videoHeight );
     webgazer.setVideoViewerSize( webgazer.params.videoViewerWidth, webgazer.params.videoViewerHeight );
 
-    document.body.appendChild(videoElementCanvas);
-    document.body.appendChild(faceOverlay);
-    document.body.appendChild(faceFeedbackBox);
+    videoContainerElement.appendChild(videoElementCanvas);
+    videoContainerElement.appendChild(faceOverlay);
+    videoContainerElement.appendChild(faceFeedbackBox);
     document.body.appendChild(gazeDot);
 
     // Run this only once, so remove the event listener
@@ -757,6 +765,9 @@ webgazer.showVideo = function(val) {
   webgazer.params.showVideo = val;
   if(videoElement) {
     videoElement.style.display = val ? 'block' : 'none';
+  }
+  if(videoContainerElement) {
+    videoContainerElement.style.display = val ? 'block' : 'none';
   }
   return webgazer;
 };

--- a/src/params.mjs
+++ b/src/params.mjs
@@ -1,5 +1,6 @@
 const params = {
   moveTickSize: 50,
+  videoContainerId: 'webgazerVideoContainer',
   videoElementId: 'webgazerVideoFeed',
   videoElementCanvasId: 'webgazerVideoCanvas',
   faceOverlayId: 'webgazerFaceOverlay',


### PR DESCRIPTION
Hi WebGazer team!

I'm the developer of [jsPsych](https://github.com/jspsych/jsPsych), a JS library for creating behavioral experiments. We recently added support for WebGazer in our latest release.

I've been working on some small improvements to our support, and one of the things that I would really like to be able to do is better control where on the page the video preview appears. 

This pull request puts all of the video preview elements inside a new `<div>`. The default position of the `<div>` is the same as the current code (`position: fixed`, top-left corner), but by grouping all of these elements together it's now easier to add some CSS that will move the whole group of elements together on the page. For example, to center them:

![image](https://user-images.githubusercontent.com/595524/109524778-e3212400-7a7e-11eb-8c79-edebd78aac1d.png)

I hope that I've followed your style conventions and made all the necessary changes to enable a simple merge if you'd like to add this functionality. Let me know if there are other places in the code that I should be making adjustments.

