### PR TITLE
Refactor: replace numeric with mathjs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,14 @@
       "integrity": "sha512-MggwidiH+E9j5Sh8pbrX5sJvMcsqS5o+7iB42M9/k0CD63MjYbdP4nhSh7uB5wnv2/RVzTZFTxzF/kIa5mrCqA==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@tensorflow-models/blazeface": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/@tensorflow-models/blazeface/-/blazeface-0.0.5.tgz",
@@ -1802,6 +1810,11 @@
       "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
       "dev": true
     },
+    "complex.js": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.13.tgz",
+      "integrity": "sha512-UEWd3G3/kd3lJmsdLsDh9qfinJlujL4hIFn3Vo4/G5eqehPsgCHf2CLhFs77tVkOp2stt/jbNit7Q1XFANFltA=="
+    },
     "component-bind": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
@@ -2061,6 +2074,11 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
+    },
+    "decimal.js": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -2546,6 +2564,11 @@
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
       "dev": true
     },
+    "escape-latex": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/escape-latex/-/escape-latex-1.2.0.tgz",
+      "integrity": "sha512-nV5aVWW1K0wEiUIEdZ4erkGGH8mDxGyxSeqPzRNtWP7ataw+/olFObw7hujFWlVjNsaDFw5VZ5NzVSIqRgfTiw=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -3011,6 +3034,11 @@
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
+    },
+    "fraction.js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.1.1.tgz",
+      "integrity": "sha512-MHOhvvxHTfRFpF1geTK9czMIZ6xclsEor2wkIGYYq+PxcQqT7vStJqjhe6S1TenZrMZzo+wlqOufBDVepUEgPg=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -3971,6 +3999,11 @@
         "iterate-iterator": "^1.0.1"
       }
     },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha1-+eIwPUUH9tdDVac2ZNFED7Wg71k="
+    },
     "js-message": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/js-message/-/js-message-1.0.5.tgz",
@@ -4507,6 +4540,29 @@
       "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
       "dev": true
     },
+    "mathjs": {
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-9.4.2.tgz",
+      "integrity": "sha512-xu0AU6bpjxbDgCB824s/yDpAe0KR1TMUYz/yY7rYyRcEH56OuG8JPgxJhqlUyhhRpY++ZFDnRxRNGChYx1FLKQ==",
+      "requires": {
+        "@babel/runtime": "^7.14.0",
+        "complex.js": "^2.0.13",
+        "decimal.js": "^10.2.1",
+        "escape-latex": "^1.2.0",
+        "fraction.js": "^4.1.1",
+        "javascript-natural-sort": "^0.7.1",
+        "seedrandom": "^3.0.5",
+        "tiny-emitter": "^2.1.0",
+        "typed-function": "^2.0.0"
+      },
+      "dependencies": {
+        "seedrandom": {
+          "version": "3.0.5",
+          "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+          "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg=="
+        }
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -5011,11 +5067,6 @@
       "requires": {
         "path-key": "^2.0.0"
       }
-    },
-    "numeric": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
-      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -6971,6 +7022,11 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
+    },
     "to-array": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
@@ -7048,6 +7104,11 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
+    },
+    "typed-function": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-2.0.0.tgz",
+      "integrity": "sha512-Hhy1Iwo/e4AtLZNK10ewVVcP2UEs408DS35ubP825w/YgSBK1KVLwALvvIG4yX75QJrxjCpcWkzkVRB0BwwYlA=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@tensorflow-models/facemesh": "0.0.3",
     "@tensorflow/tfjs": "^3.5.0",
     "localforage": "1.7.3",
-    "numeric": "1.2.6",
+    "mathjs": "^9.4.2",
     "regression": "2.0.1"
   },
   "devDependencies": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3,6 +3,7 @@ import '@tensorflow/tfjs';
 //import(/* webpackChunkName: 'pageA' */ './vendors~main.js')
 
 import 'regression';
+import mathjs from 'mathjs';
 import params from './params';
 import './dom_util';
 import localforage from 'localforage';
@@ -11,6 +12,12 @@ import Reg from './ridgeReg';
 import ridgeRegWeighted from './ridgeWeightedReg';
 import ridgeRegThreaded from './ridgeRegThreaded';
 import util from './util';
+
+// Sets mathjs matrix outputs to arrays
+// @see: https://mathjs.org/docs/core/configuration.html
+mathjs.config({
+  matrix: 'Array',
+});
 
 const webgazer = {};
 webgazer.tracker = {};
@@ -490,7 +497,7 @@ async function init(stream) {
   videoContainerElement.style.left = leftDist;
   videoContainerElement.style.width = webgazer.params.videoViewerWidth + 'px';
   videoContainerElement.style.height = webgazer.params.videoViewerHeight + 'px';
-  
+
   videoElement = document.createElement('video');
   videoElement.setAttribute('playsinline', '');
   videoElement.id = webgazer.params.videoElementId;
@@ -583,8 +590,8 @@ async function init(stream) {
 /**
  * Initializes navigator.mediaDevices.getUserMedia
  * depending on the browser capabilities
- * 
- * @return Promise 
+ *
+ * @return Promise
  */
 function setUserMediaVariable(){
 
@@ -818,10 +825,10 @@ webgazer.showPredictionPoints = function(val) {
 /**
  * Set whether localprevious calibration data (from localforage) should be loaded.
  * Default true.
- * 
+ *
  * NOTE: Should be called before webgazer.begin() -- see www/js/main.js for example
- * 
- * @param val 
+ *
+ * @param val
  * @returns {webgazer} this
  */
 webgazer.saveDataAcrossSessions = function(val) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -3,7 +3,6 @@ import '@tensorflow/tfjs';
 //import(/* webpackChunkName: 'pageA' */ './vendors~main.js')
 
 import 'regression';
-import mathjs from 'mathjs';
 import params from './params';
 import './dom_util';
 import localforage from 'localforage';
@@ -12,12 +11,6 @@ import Reg from './ridgeReg';
 import ridgeRegWeighted from './ridgeWeightedReg';
 import ridgeRegThreaded from './ridgeRegThreaded';
 import util from './util';
-
-// Sets mathjs matrix outputs to arrays
-// @see: https://mathjs.org/docs/core/configuration.html
-mathjs.config({
-  matrix: 'Array',
-});
 
 const webgazer = {};
 webgazer.tracker = {};

--- a/src/mathjs.mjs
+++ b/src/mathjs.mjs
@@ -1,0 +1,8 @@
+import mathjs from 'mathjs';
+
+// The global mathjs configuration is read-only,
+// so we create a new instance and set matrix outputs to arrays
+// @see: https://mathjs.org/docs/core/configuration.html
+export default mathjs.create(mathjs.all, {
+  matrix: 'Array',
+});

--- a/src/ridgeRegThreaded.mjs
+++ b/src/ridgeRegThreaded.mjs
@@ -1,5 +1,5 @@
 import util from './util';
-import numeric from 'numeric';
+import mathjs from 'mathjs';
 import util_regression from './util_regression';
 import params from './params';
 
@@ -61,7 +61,7 @@ reg.RidgeRegThreaded.prototype.init = function() {
               [1/2, 0,    1,   0],  
               [0,  1/2,  0,   1]];// * delta_t  
     var delta_t = 1/10; // The amount of time between frames    
-    Q = numeric.mul(Q, delta_t);    
+    Q = mathjs.multiply(Q, delta_t);    
 
     var H = [ [1, 0, 0, 0, 0, 0],   
               [0, 1, 0, 0, 0, 0],   
@@ -72,9 +72,9 @@ reg.RidgeRegThreaded.prototype.init = function() {
     var pixel_error = 47; //We will need to fine tune this value [20200611 xk] I just put a random value here   
 
     //This matrix represents the expected measurement error 
-    var R = numeric.mul(numeric.identity(2), pixel_error);  
+    var R = mathjs.multiply(mathjs.identity(2), pixel_error);  
 
-    var P_initial = numeric.mul(numeric.identity(4), 0.0001); //Initial covariance matrix   
+    var P_initial = mathjs.multiply(mathjs.identity(4), 0.0001); //Initial covariance matrix
     var x_initial = [[500], [500], [0], [0]]; // Initial measurement matrix 
 
     this.kalman = new util_regression.KalmanFilter(F, H, Q, R, P_initial, x_initial);  

--- a/src/ridgeRegThreaded.mjs
+++ b/src/ridgeRegThreaded.mjs
@@ -1,5 +1,5 @@
 import util from './util';
-import mathjs from 'mathjs';
+import mathjs from './mathjs';
 import util_regression from './util_regression';
 import params from './params';
 

--- a/src/util.mjs
+++ b/src/util.mjs
@@ -1,6 +1,5 @@
 import mat from './mat';
 import params from './params';
-import numeric from 'numeric';
 
 const util = {};
 

--- a/src/util_regression.mjs
+++ b/src/util_regression.mjs
@@ -102,7 +102,8 @@ util_regression.KalmanFilter.prototype.update = function(z) {
     var P_p = add(mult(mult(this.F,this.P), transpose(this.F)), this.Q); //Predicted covaraince
 
     //Calculate the update values
-    var y = sub(z, mult(this.H, X_p)); // This is the measurement error (between what we expect and the actual value)
+    // Use `squeeze` to transform the multiplied value to match the measurement's form, i.e. column vector => row vector
+    var y = sub(z, mathjs.squeeze(mult(this.H, X_p))); // This is the measurement error (between what we expect and the actual value)
     var S = add(mult(mult(this.H, P_p), transpose(this.H)), this.R); //This is the residual covariance (the error in the covariance)
 
     // kalman multiplier: K = P * H' * (H * P * H' + R)^-1
@@ -117,7 +118,7 @@ util_regression.KalmanFilter.prototype.update = function(z) {
     // correction: X = X + K * (m - H * X)  |  P = (I - K * H) * P
     this.X = add(X_p, mult(K, y));
     this.P = mult(sub(identity(K.length), mult(K,this.H)), P_p);
-    return transpose(mult(this.H, this.X))[0]; //Transforms the predicted state back into it's measurement form
+    return mathjs.squeeze(mult(this.H, this.X)); //Transforms the predicted state back into it's measurement form
 };
 
 /**

--- a/src/util_regression.mjs
+++ b/src/util_regression.mjs
@@ -1,5 +1,5 @@
 import util from './util';
-import numeric from 'numeric';
+import mathjs from 'mathjs';
 import mat from './mat';
 import params from './params';
 
@@ -46,7 +46,7 @@ util_regression.InitRegression = function() {
     [1/2, 0,    1,   0],
     [0,  1/2,  0,   1]];// * delta_t
   var delta_t = 1/10; // The amount of time between frames
-  Q = numeric.mul(Q, delta_t);
+  Q = mathjs.multiply(Q, delta_t);
 
   var H = [ [1, 0, 0, 0, 0, 0],
     [0, 1, 0, 0, 0, 0],
@@ -57,9 +57,9 @@ util_regression.InitRegression = function() {
   var pixel_error = 47; //We will need to fine tune this value [20200611 xk] I just put a random value here
 
   //This matrix represents the expected measurement error
-  var R = numeric.mul(numeric.identity(2), pixel_error);
+  var R = mathjs.multiply(mathjs.identity(2), pixel_error);
 
-  var P_initial = numeric.mul(numeric.identity(4), 0.0001); //Initial covariance matrix
+  var P_initial = mathjs.multiply(mathjs.identity(4), 0.0001); //Initial covariance matrix
   var x_initial = [[500], [500], [0], [0]]; // Initial measurement matrix
 
   this.kalman = new util_regression.KalmanFilter(F, H, Q, R, P_initial, x_initial);
@@ -93,7 +93,7 @@ util_regression.KalmanFilter = function(F, H, Q, R, P_initial, X_initial) {
  */
 util_regression.KalmanFilter.prototype.update = function(z) {
     // Here, we define all the different matrix operations we will need
-    var add = numeric.add, sub = numeric.sub, inv = numeric.inv, identity = numeric.identity;
+    var add = mathjs.add, sub = mathjs.subtract, inv = mathjs.inv, identity = mathjs.identity;
     var mult = mat.mult, transpose = mat.transpose;
     //TODO cache variables like the transpose of H
 
@@ -150,7 +150,9 @@ util_regression.ridge = function(y, X, k){
             if (m_Coefficients.length*n !== m_Coefficients.length){
                 console.log('Array length must be a multiple of m')
             }
-            solution = (ss.length === ss[0].length ? (numeric.LUsolve(numeric.LU(ss,true),bb)) : (webgazer.mat.QRDecomposition(ss,bb)));
+            solution = ss.length === ss[0].length ? 
+              mathjs.squeeze(mathjs.lusolve(ss, bb)) : // lusolve returns a column vector, so squeeze it
+              webgazer.mat.QRDecomposition(ss,bb);
 
             for (var i = 0; i < nc; i++){
                 m_Coefficients[i] = solution[i];

--- a/src/util_regression.mjs
+++ b/src/util_regression.mjs
@@ -93,21 +93,22 @@ util_regression.KalmanFilter = function(F, H, Q, R, P_initial, X_initial) {
  */
 util_regression.KalmanFilter.prototype.update = function(z) {
     // Here, we define all the different matrix operations we will need
-    var add = mathjs.add, sub = mathjs.subtract, inv = mathjs.inv, identity = mathjs.identity;
-    var mult = mat.mult, transpose = mat.transpose;
+    const {
+      add, subtract, inv, identity, multiply, transpose,
+    } = mathjs;
     //TODO cache variables like the transpose of H
 
     // prediction: X = F * X  |  P = F * P * F' + Q
-    var X_p = mult(this.F, this.X); //Update state vector
-    var P_p = add(mult(mult(this.F,this.P), transpose(this.F)), this.Q); //Predicted covaraince
+    var X_p = multiply(this.F, this.X); //Update state vector
+    var P_p = add(multiply(multiply(this.F,this.P), transpose(this.F)), this.Q); //Predicted covaraince
 
     //Calculate the update values
     // Use `squeeze` to transform the multiplied value to match the measurement's form, i.e. column vector => row vector
-    var y = sub(z, mathjs.squeeze(mult(this.H, X_p))); // This is the measurement error (between what we expect and the actual value)
-    var S = add(mult(mult(this.H, P_p), transpose(this.H)), this.R); //This is the residual covariance (the error in the covariance)
+    var y = subtract(z, mathjs.squeeze(multiply(this.H, X_p))); // This is the measurement error (between what we expect and the actual value)
+    var S = add(multiply(multiply(this.H, P_p), transpose(this.H)), this.R); //This is the residual covariance (the error in the covariance)
 
     // kalman multiplier: K = P * H' * (H * P * H' + R)^-1
-    var K = mult(P_p, mult(transpose(this.H), inv(S))); //This is the Optimal Kalman Gain
+    var K = multiply(P_p, multiply(transpose(this.H), inv(S))); //This is the Optimal Kalman Gain
 
     //We need to change Y into it's column vector form
     for(var i = 0; i < y.length; i++){
@@ -116,9 +117,9 @@ util_regression.KalmanFilter.prototype.update = function(z) {
 
     //Now we correct the internal values of the model
     // correction: X = X + K * (m - H * X)  |  P = (I - K * H) * P
-    this.X = add(X_p, mult(K, y));
-    this.P = mult(sub(identity(K.length), mult(K,this.H)), P_p);
-    return mathjs.squeeze(mult(this.H, this.X)); //Transforms the predicted state back into it's measurement form
+    this.X = add(X_p, multiply(K, y));
+    this.P = multiply(subtract(identity(K.length), multiply(K,this.H)), P_p);
+    return mathjs.squeeze(multiply(this.H, this.X)); //Transforms the predicted state back into it's measurement form
 };
 
 /**
@@ -151,7 +152,7 @@ util_regression.ridge = function(y, X, k){
             if (m_Coefficients.length*n !== m_Coefficients.length){
                 console.log('Array length must be a multiple of m')
             }
-            solution = ss.length === ss[0].length ? 
+            solution = ss.length === ss[0].length ?
               mathjs.squeeze(mathjs.lusolve(ss, bb)) : // lusolve returns a column vector, so squeeze it
               webgazer.mat.QRDecomposition(ss,bb);
 

--- a/src/util_regression.mjs
+++ b/src/util_regression.mjs
@@ -1,5 +1,5 @@
 import util from './util';
-import mathjs from 'mathjs';
+import mathjs from './mathjs';
 import mat from './mat';
 import params from './params';
 

--- a/src/util_regression.mjs
+++ b/src/util_regression.mjs
@@ -103,17 +103,13 @@ util_regression.KalmanFilter.prototype.update = function(z) {
     var P_p = add(multiply(multiply(this.F,this.P), transpose(this.F)), this.Q); //Predicted covaraince
 
     //Calculate the update values
-    // Use `squeeze` to transform the multiplied value to match the measurement's form, i.e. column vector => row vector
-    var y = subtract(z, mathjs.squeeze(multiply(this.H, X_p))); // This is the measurement error (between what we expect and the actual value)
+    // reshape measurement into a column vector form
+    z = mathjs.reshape(z, [-1, 1])
+    var y = subtract(z, multiply(this.H, X_p)); // This is the measurement error (between what we expect and the actual value)
     var S = add(multiply(multiply(this.H, P_p), transpose(this.H)), this.R); //This is the residual covariance (the error in the covariance)
 
     // kalman multiplier: K = P * H' * (H * P * H' + R)^-1
     var K = multiply(P_p, multiply(transpose(this.H), inv(S))); //This is the Optimal Kalman Gain
-
-    //We need to change Y into it's column vector form
-    for(var i = 0; i < y.length; i++){
-        y[i] = [y[i]];
-    }
 
     //Now we correct the internal values of the model
     // correction: X = X + K * (m - H * X)  |  P = (I - K * H) * P

--- a/src/worker_scripts/util.js
+++ b/src/worker_scripts/util.js
@@ -378,7 +378,8 @@
       var P_p = add(mult(mult(this.F,this.P), transpose(this.F)), this.Q); //Predicted covaraince
 
       //Calculate the update values
-      var y = sub(z, mult(this.H, X_p)); // This is the measurement error (between what we expect and the actual value)
+      // Use `squeeze` to transform the multiplied value to match the measurement's form, i.e. column vector => row vector
+      var y = sub(z, mathjs.squeeze(mult(this.H, X_p))); // This is the measurement error (between what we expect and the actual value)
       var S = add(mult(mult(this.H, P_p), transpose(this.H)), this.R); //This is the residual covariance (the error in the covariance)
 
       // kalman multiplier: K = P * H' * (H * P * H' + R)^-1
@@ -393,7 +394,7 @@
       // correction: X = X + K * (m - H * X)  |  P = (I - K * H) * P
       this.X = add(X_p, mult(K, y));
       this.P = mult(sub(identity(K.length), mult(K,this.H)), P_p);
-      return transpose(mult(this.H, this.X))[0]; //Transforms the predicted state back into it's measurement form
+      return mathjs.squeeze(mult(this.H, this.X)); //Transforms the predicted state back into it's measurement form
     };
 
 }());

--- a/src/worker_scripts/util.js
+++ b/src/worker_scripts/util.js
@@ -368,7 +368,8 @@
     self.webgazer.util.KalmanFilter.prototype.update = function(z) {
 
       // Here, we define all the different matrix operations we will need
-      var add = numeric.add, sub = numeric.sub, inv = numeric.inv, identity = numeric.identity;
+      // FIXME: mathjs is not exported to worker global scope  
+      var add = mathjs.add, sub = mathjs.subtract, inv = mathjs.inv, identity = mathjs.identity;
       var mult = webgazer.mat.mult, transpose = webgazer.mat.transpose;
       //TODO cache variables like the transpose of H
 


### PR DESCRIPTION
Resolves #211.

This PR replaced numeric with [mathjs](https://github.com/josdejong/mathjs) to fix the CSP error as mentioned in #211.
I'm not able to run the test script because files under `www/data/src/P_01/` are missing, but the demo pages seem to be working.

As a side effect, the bundle size increased from 2.1M to 3.2M (both minified).