### PR TITLE
Refactor: remove numeric and reimplement necessary matrix operations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5012,11 +5012,6 @@
         "path-key": "^2.0.0"
       }
     },
-    "numeric": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/numeric/-/numeric-1.2.6.tgz",
-      "integrity": "sha1-dlsCvvl5iPz4gNTrPza4D6MTNao="
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "@tensorflow-models/facemesh": "0.0.3",
     "@tensorflow/tfjs": "^3.5.0",
     "localforage": "1.7.3",
-    "numeric": "1.2.6",
     "regression": "2.0.1"
   },
   "devDependencies": {

--- a/src/mat.mjs
+++ b/src/mat.mjs
@@ -1,301 +1,479 @@
-const mat = {};
 /**
- * Transposes an mxn array
- * @param {Array.<Array.<Number>>} matrix - of 'M x N' dimensionality
- * @return {Array.<Array.<Number>>} transposed matrix
+ * Matrix operations, mostly based on WEKA
+ * @see https://github.com/Waikato/weka-3.8/blob/master/weka/src/main/java/weka/core/matrix/Matrix.java
  */
-mat.transpose = function(matrix){
-    var m = matrix.length;
-    var n = matrix[0].length;
-    var transposedMatrix = new Array(n);
 
-    for (var i = 0; i < m; i++){
-        for (var j = 0; j < n; j++){
-            if (i === 0) transposedMatrix[j] = new Array(m);
-            transposedMatrix[j][i] = matrix[i][j];
+/**
+ * @callback operationCallback
+ * @param {number} a - an element of matrix A
+ * @param {number} b - an element of matrix B
+ * @return {number} a ○ b
+ */
+/**
+ * Apply arithmetic operations to every element of A and B:
+ * X = A ○ B, where ○ can be one of +, -, *, /, etc.
+ *
+ * @param {Array.<Array.<Number>>} A
+ * @param {Array.<Array.<Number>>} B
+ * @param {operationCallback} op - operation to apply, op(a, b) => a ○ b
+ * @return {Array.<Array.<Number>>} A ○ B
+ */
+function applyArithmeticOperation(A, B, op) {
+    if (A.length !== B.length || A[0].length !== B[0].length) {
+        throw new Error('Matrix dimensions must agree.');
+    }
+
+    const rows = A.length;
+    const cols = A[0].length;
+
+    const X = new Array(rows);
+
+    for (let i = 0; i < rows; i++) {
+        X[i] = new Array(cols);
+
+        for (let j = 0; j < cols; j++) {
+            X[i][j] = op(A[i][j], B[i][j]);
         }
     }
 
-    return transposedMatrix;
-};
-
-/**
- * Get a sub-matrix of matrix
- * @param {Array.<Array.<Number>>} matrix - original matrix
- * @param {Array.<Number>} r - Array of row indices
- * @param {Number} j0 - Initial column index
- * @param {Number} j1 - Final column index
- * @returns {Array} The sub-matrix matrix(r(:),j0:j1)
- */
-mat.getMatrix = function(matrix, r, j0, j1){
-    var X = new Array(r.length),
-        m = j1-j0+1;
-
-    for (var i = 0; i < r.length; i++){
-        X[i] = new Array(m);
-        for (var j = j0; j <= j1; j++){
-            X[i][j-j0] = matrix[r[i]][j];
-        }
-    }
     return X;
-};
-
-/**
- * Get a submatrix of matrix
- * @param {Array.<Array.<Number>>} matrix - original matrix
- * @param {Number} i0 - Initial row index
- * @param {Number} i1 - Final row index
- * @param {Number} j0 - Initial column index
- * @param {Number} j1 - Final column index
- * @return {Array} The sub-matrix matrix(i0:i1,j0:j1)
- */
-mat.getSubMatrix = function(matrix, i0, i1, j0, j1){
-    var size = j1 - j0 + 1,
-        X = new Array(i1-i0+1);
-
-    for (var i = i0; i <= i1; i++){
-        var subI = i-i0;
-
-        X[subI] = new Array(size);
-
-        for (var j = j0; j <= j1; j++){
-            X[subI][j-j0] = matrix[i][j];
-        }
-    }
-    return X;
-};
-
-/**
- * Linear algebraic matrix multiplication, matrix1 * matrix2
- * @param {Array.<Array.<Number>>} matrix1
- * @param {Array.<Array.<Number>>} matrix2
- * @return {Array.<Array.<Number>>} Matrix product, matrix1 * matrix2
- */
-mat.mult = function(matrix1, matrix2){
-
-    if (matrix2.length != matrix1[0].length){
-        console.log('Matrix inner dimensions must agree:');
-
-    }
-
-    var X = new Array(matrix1.length),
-        Bcolj = new Array(matrix1[0].length);
-
-    for (var j = 0; j < matrix2[0].length; j++){
-        for (var k = 0; k < matrix1[0].length; k++){
-            Bcolj[k] = matrix2[k][j];
-        }
-        for (var i = 0; i < matrix1.length; i++){
-
-            if (j === 0)
-                X[i] = new Array(matrix2[0].length);
-
-            var Arowi = matrix1[i];
-            var s = 0;
-            for (var k = 0; k < matrix1[0].length; k++){
-                s += Arowi[k]*Bcolj[k];
-            }
-            X[i][j] = s;
-        }
-    }
-    return X;
-};
-
-
-/**
- * LUDecomposition to solve A*X = B, based on WEKA code
- * @param {Array.<Array.<Number>>} A - left matrix of equation to be solved
- * @param {Array.<Array.<Number>>} B - right matrix of equation to be solved
- * @return {Array.<Array.<Number>>} X so that L*U*X = B(piv,:)
- */
-mat.LUDecomposition = function(A,B){
-    var LU = new Array(A.length);
-
-    for (var i = 0; i < A.length; i++){
-        LU[i] = new Array(A[0].length);
-        for (var j = 0; j < A[0].length; j++){
-            LU[i][j] = A[i][j];
-        }
-    }
-
-    var m = A.length;
-    var n = A[0].length;
-    var piv = new Array(m);
-    for (var i = 0; i < m; i++){
-        piv[i] = i;
-    }
-    var pivsign = 1;
-    var LUrowi = new Array();
-    var LUcolj = new Array(m);
-    // Outer loop.
-    for (var j = 0; j < n; j++){
-        // Make a copy of the j-th column to localize references.
-        for (var i = 0; i < m; i++){
-            LUcolj[i] = LU[i][j];
-        }
-        // Apply previous transformations.
-        for (var i = 0; i < m; i++){
-            LUrowi = LU[i];
-            // Most of the time is spent in the following dot product.
-            var kmax = Math.min(i,j);
-            var s = 0;
-            for (var k = 0; k < kmax; k++){
-                s += LUrowi[k]*LUcolj[k];
-            }
-            LUrowi[j] = LUcolj[i] -= s;
-        }
-        // Find pivot and exchange if necessary.
-        var p = j;
-        for (var i = j+1; i < m; i++){
-            if (Math.abs(LUcolj[i]) > Math.abs(LUcolj[p])){
-                p = i;
-            }
-        }
-        if (p != j){
-            for (var k = 0; k < n; k++){
-                var t = LU[p][k];
-                LU[p][k] = LU[j][k];
-                LU[j][k] = t;
-            }
-            var k = piv[p];
-            piv[p] = piv[j];
-            piv[j] = k;
-            pivsign = -pivsign;
-        }
-        // Compute multipliers.
-        if (j < m & LU[j][j] != 0){
-            for (var i = j+1; i < m; i++){
-                LU[i][j] /= LU[j][j];
-            }
-        }
-    }
-    if (B.length != m){
-        console.log('Matrix row dimensions must agree.');
-    }
-    for (var j = 0; j < n; j++){
-        if (LU[j][j] === 0){
-            console.log('Matrix is singular.')
-        }
-    }
-    var nx = B[0].length;
-    var X = self.webgazer.mat.getMatrix(B,piv,0,nx-1);
-    // Solve L*Y = B(piv,:)
-    for (var k = 0; k < n; k++){
-        for (var i = k+1; i < n; i++){
-            for (var j = 0; j < nx; j++){
-                X[i][j] -= X[k][j]*LU[i][k];
-            }
-        }
-    }
-    // Solve U*X = Y;
-    for (var k = n-1; k >= 0; k--){
-        for (var j = 0; j < nx; j++){
-            X[k][j] /= LU[k][k];
-        }
-        for (var i = 0; i < k; i++){
-            for (var j = 0; j < nx; j++){
-                X[i][j] -= X[k][j]*LU[i][k];
-            }
-        }
-    }
-    return X;
-};
-
-/**
- * Least squares solution of A*X = B, based on WEKA code
- * @param {Array.<Array.<Number>>} A - left side matrix to be solved
- * @param {Array.<Array.<Number>>} B - a matrix with as many rows as A and any number of columns.
- * @return {Array.<Array.<Number>>} X - that minimizes the two norms of QR*X-B.
- */
-mat.QRDecomposition = function(A, B){
-    // Initialize.
-    var QR = new Array(A.length);
-
-    for (var i = 0; i < A.length; i++){
-        QR[i] = new Array(A[0].length);
-        for (var j = 0; j < A[0].length; j++){
-            QR[i][j] = A[i][j];
-        }
-    }
-    var m = A.length;
-    var n = A[0].length;
-    var Rdiag = new Array(n);
-    var nrm;
-
-    // Main loop.
-    for (var k = 0; k < n; k++){
-        // Compute 2-norm of k-th column without under/overflow.
-        nrm = 0;
-        for (var i = k; i < m; i++){
-            nrm = Math.hypot(nrm,QR[i][k]);
-        }
-        if (nrm != 0){
-            // Form k-th Householder vector.
-            if (QR[k][k] < 0){
-                nrm = -nrm;
-            }
-            for (var i = k; i < m; i++){
-                QR[i][k] /= nrm;
-            }
-            QR[k][k] += 1;
-
-            // Apply transformation to remaining columns.
-            for (var j = k+1; j < n; j++){
-                var s = 0;
-                for (var i = k; i < m; i++){
-                    s += QR[i][k]*QR[i][j];
-                }
-                s = -s/QR[k][k];
-                for (var i = k; i < m; i++){
-                    QR[i][j] += s*QR[i][k];
-                }
-            }
-        }
-        Rdiag[k] = -nrm;
-    }
-    if (B.length != m){
-        console.log('Matrix row dimensions must agree.');
-    }
-    for (var j = 0; j < n; j++){
-        if (Rdiag[j] === 0)
-            console.log('Matrix is rank deficient');
-    }
-    // Copy right hand side
-    var nx = B[0].length;
-    var X = new Array(B.length);
-    for(var i=0; i<B.length; i++){
-        X[i] = new Array(B[0].length);
-    }
-    for (var i = 0; i < B.length; i++){
-        for (var j = 0; j < B[0].length; j++){
-            X[i][j] = B[i][j];
-        }
-    }
-    // Compute Y = transpose(Q)*B
-    for (var k = 0; k < n; k++){
-        for (var j = 0; j < nx; j++){
-            var s = 0.0;
-            for (var i = k; i < m; i++){
-                s += QR[i][k]*X[i][j];
-            }
-            s = -s/QR[k][k];
-            for (var i = k; i < m; i++){
-                X[i][j] += s*QR[i][k];
-            }
-        }
-    }
-    // Solve R*X = Y;
-    for (var k = n-1; k >= 0; k--){
-        for (var j = 0; j < nx; j++){
-            X[k][j] /= Rdiag[k];
-        }
-        for (var i = 0; i < k; i++){
-            for (var j = 0; j < nx; j++){
-                X[i][j] -= X[k][j]*QR[i][k];
-            }
-        }
-    }
-    return mat.getSubMatrix(X,0,n-1,0,nx-1);
 }
+
+const mat = {
+    /**
+     * Transposes an m*n array
+     * @param {Array.<Array.<Number>>} matrix - of 'M x N' dimensionality
+     * @return {Array.<Array.<Number>>} transposed matrix
+     */
+    transpose(matrix) {
+        const rows = matrix.length;
+        const cols = matrix[0].length;
+        const transposedMatrix = new Array(cols);
+
+        for (let j = 0; j < cols; j++) {
+            transposedMatrix[j] = new Array(rows);
+
+            for (let i = 0; i < rows; i++) {
+                transposedMatrix[j][i] = matrix[i][j];
+            }
+        }
+
+        return transposedMatrix;
+    },
+
+    /**
+     * Get a sub-matrix of matrix
+     * @param {Array.<Array.<Number>>} matrix - original matrix
+     * @param {Array.<Number>} r - Array of row indices
+     * @param {Number} j0 - Initial column index
+     * @param {Number} j1 - Final column index
+     * @returns {Array} The sub-matrix matrix(r(:),j0:j1)
+     */
+    getMatrix(matrix, r, j0, j1) {
+        const X = new Array(r.length);
+        const m = j1 - j0 + 1;
+
+        for (let i = 0, len = r.length; i < len; i++) {
+            X[i] = new Array(m);
+
+            for (let j = j0; j <= j1; j++) {
+                X[i][j - j0] = matrix[r[i]][j];
+            }
+        }
+
+        return X;
+    },
+
+    /**
+     * Get a submatrix of matrix
+     * @param {Array.<Array.<Number>>} matrix - original matrix
+     * @param {Number} i0 - Initial row index
+     * @param {Number} i1 - Final row index
+     * @param {Number} j0 - Initial column index
+     * @param {Number} j1 - Final column index
+     * @return {Array} The sub-matrix matrix(i0:i1,j0:j1)
+     */
+    getSubMatrix(matrix, i0, i1, j0, j1) {
+        const size = j1 - j0 + 1;
+        const X = new Array(i1 - i0 + 1);
+
+        for (let i = i0; i <= i1; i++) {
+            const subI = i - i0;
+            X[subI] = new Array(size);
+
+            for (let j = j0; j <= j1; j++) {
+                X[subI][j - j0] = matrix[i][j];
+            }
+        }
+
+        return X;
+    },
+
+    /**
+     * Linear algebraic matrix multiplication, X = A * B
+     * @param {Array.<Array.<Number>>} A
+     * @param {Array.<Array.<Number>>} B
+     * @return {Array.<Array.<Number>>} Matrix product, A * B
+     */
+    mult(A, B) {
+        // matrices shape
+        const rowsA = A.length, colsA = A[0].length;
+        const rowsB = B.length, colsB = B[0].length;
+
+        if (colsA !== rowsB) {
+            throw new Error('Matrix inner dimensions must agree.');
+        }
+
+        const X = new Array(rowsA);
+        const Bcolj = new Array(colsA);
+
+        for (let j = 0; j < colsB; j++) {
+            for (let k = 0; k < colsA; k++) {
+                Bcolj[k] = B[k][j];
+            }
+
+            for (let i = 0; i < rowsA; i++) {
+                if (j === 0) {
+                    X[i] = new Array(colsB);
+                }
+
+                const Arowi = A[i];
+                let s = 0;
+
+                for (let k = 0; k < colsA; k++) {
+                    s += Arowi[k] * Bcolj[k];
+                }
+
+                X[i][j] = s;
+            }
+        }
+
+        return X;
+    },
+
+    /**
+     * Multiply a matrix by a scalar, X = s*A
+     * @param {Array.<Array.<Number>>}  A - matrix
+     * @param {Number}                  s - scalar
+     * @return {Array.<Array.<Number>>} s*A
+     */
+    multScalar(A, s) {
+        const rows = A.length;
+        const cols = A[0].length;
+
+        const X = new Array(rows);
+
+        for (let i = 0; i < rows; i++) {
+            X[i] = new Array(cols);
+
+            for (let j = 0; j < cols; j++) {
+                X[i][j] = A[i][j] * s;
+            }
+        }
+
+        return X;
+    },
+
+    /**
+     * Linear algebraic matrix addition, X = A * B
+     * @param {Array.<Array.<Number>>} A
+     * @param {Array.<Array.<Number>>} B
+     * @return {Array.<Array.<Number>>} A + B
+     */
+    add(A, B) {
+        return applyArithmeticOperation(A, B, (a, b) => a + b);
+    },
+
+    /**
+     * Linear algebraic matrix subtraction, X = A - B
+     * @param {Array.<Array.<Number>>} A
+     * @param {Array.<Array.<Number>>} B
+     * @return {Array.<Array.<Number>>} A - B
+     */
+    sub(A, B) {
+       return applyArithmeticOperation(A, B, (a, b) => a - b);
+    },
+
+    /**
+     * Matrix inverse or pseudoinverse, based on WEKA code
+     * @param {Array.<Array.<Number>>} A - original matrix
+     * @return inverse(A) if A is square, pseudoinverse otherwise.
+     */
+    inv(A) {
+        return mat.solve(A, mat.identity(A.length, A[0].length));
+    },
+
+    /**
+     * Generate identity matrix, based on WEKA code
+     * @param {Number} m - number of rows.
+     * @param {Number} [n] - number of colums, n = m if undefined.
+     * @return {Array.<Array.<Number>>} An m * n matrix with ones on the diagonal and zeros elsewhere.
+     */
+    identity(m, n = m) {
+        const X = new Array(m);
+
+        for (let i = 0; i < m; i++) {
+            X[i] = new Array(n);
+
+            for (let j = 0; j < n; j++) {
+                X[i][j] = (i === j ? 1.0 : 0.0);
+            }
+        }
+
+        return X;
+    },
+
+    /**
+     * Solve A*X = B, based on WEKA code
+     * @param {Array.<Array.<Number>>} A - left matrix of equation to be solved
+     * @param {Array.<Array.<Number>>} B - right matrix of equation to be solved
+     * @return {Array.<Array.<Number>>}  solution if A is square, least squares solution otherwiseis
+     */
+    solve(A, B) {
+        if (A.length === A[0].lenth) {
+            // A is square
+            return mat.LUDecomposition(A, B);
+        }
+
+        return mat.QRDecomposition(A, B);
+    },
+
+    /**
+     * LUDecomposition to solve A*X = B, based on WEKA code
+     * @param {Array.<Array.<Number>>} A - left matrix of equation to be solved
+     * @param {Array.<Array.<Number>>} B - right matrix of equation to be solved
+     * @return {Array.<Array.<Number>>} X so that L*U*X = B(piv,:)
+     */
+    LUDecomposition(A, B) {
+        // matrices shape
+        const rowsA = A.length, colsA = A[0].length;
+        const rowsB = B.length, colsB = B[0].length;
+
+        if (rowsA !== rowsB) {
+            throw new Error('Matrix row dimensions must agree.');
+        }
+
+        var LU = new Array(rowsA);
+
+        for (var i = 0; i < rowsA; i++) {
+            LU[i] = new Array(colsA);
+            for (var j = 0; j < colsA; j++) {
+                LU[i][j] = A[i][j];
+            }
+        }
+
+        var piv = new Array(rowsA);
+
+        for (var i = 0; i < rowsA; i++) {
+            piv[i] = i;
+        }
+
+        var pivsign = 1;
+        var LUrowi = new Array();
+        var LUcolj = new Array(rowsA);
+
+        // Outer loop.
+        for (var j = 0; j < colsA; j++) {
+            // Make a copy of the j-th column to localize references.
+            for (var i = 0; i < rowsA; i++) {
+                LUcolj[i] = LU[i][j];
+            }
+
+            // Apply previous transformations.
+            for (var i = 0; i < rowsA; i++) {
+                LUrowi = LU[i];
+                // Most of the time is spent in the following dot product.
+                var kmax = Math.min(i, j);
+                var s = 0;
+
+                for (var k = 0; k < kmax; k++) {
+                    s += LUrowi[k] * LUcolj[k];
+                }
+
+                LUrowi[j] = LUcolj[i] -= s;
+            }
+
+            // Find pivot and exchange if necessary.
+            var p = j;
+
+            for (var i = j + 1; i < rowsA; i++) {
+                if (Math.abs(LUcolj[i]) > Math.abs(LUcolj[p])) {
+                    p = i;
+                }
+            }
+
+            if (p != j) {
+                for (var k = 0; k < colsA; k++) {
+                    var t = LU[p][k];
+                    LU[p][k] = LU[j][k];
+                    LU[j][k] = t;
+                }
+
+                var k = piv[p];
+                piv[p] = piv[j];
+                piv[j] = k;
+                pivsign = -pivsign;
+            }
+
+            // Compute multipliers.
+            if (j < rowsA & LU[j][j] != 0) {
+                for (var i = j + 1; i < rowsA; i++) {
+                    LU[i][j] /= LU[j][j];
+                }
+            }
+        }
+
+        for (var j = 0; j < colsA; j++) {
+            if (LU[j][j] === 0) {
+                throw new Error('Matrix is singular.')
+            }
+        }
+
+        var X = mat.getMatrix(B, piv, 0, colsB - 1);
+
+        // Solve L*Y = B(piv,:)
+        for (var k = 0; k < colsA; k++) {
+            for (var i = k + 1; i < colsA; i++) {
+                for (var j = 0; j < colsB; j++) {
+                    X[i][j] -= X[k][j] * LU[i][k];
+                }
+            }
+        }
+
+        // Solve U*X = Y;
+        for (var k = colsA - 1; k >= 0; k--) {
+            for (var j = 0; j < colsB; j++) {
+                X[k][j] /= LU[k][k];
+            }
+
+            for (var i = 0; i < k; i++) {
+                for (var j = 0; j < colsB; j++) {
+                    X[i][j] -= X[k][j] * LU[i][k];
+                }
+            }
+        }
+
+        return X;
+    },
+
+    /**
+     * Least squares solution of A*X = B, based on WEKA code
+     * @param {Array.<Array.<Number>>} A - left side matrix to be solved
+     * @param {Array.<Array.<Number>>} B - a matrix with as many rows as A and any number of columns.
+     * @return {Array.<Array.<Number>>} X - that minimizes the two norms of QR*X-B.
+     */
+    QRDecomposition(A, B) {
+        // matrices shape
+        const rowsA = A.length, colsA = A[0].length;
+        const rowsB = B.length, colsB = B[0].length;
+
+        if (rowsA !== rowsB) {
+            throw new Error('Matrix row dimensions must agree.');
+        }
+
+        // Initialize.
+        var QR = new Array(rowsA);
+
+        for (var i = 0; i < rowsA; i++) {
+            QR[i] = new Array(colsA);
+            for (var j = 0; j < colsA; j++) {
+                QR[i][j] = A[i][j];
+            }
+        }
+
+        var Rdiag = new Array(colsA);
+        var nrm;
+
+        // Main loop.
+        for (var k = 0; k < colsA; k++) {
+            // Compute 2-norm of k-th column without under/overflow.
+            nrm = 0;
+
+            for (var i = k; i < rowsA; i++) {
+                nrm = Math.hypot(nrm, QR[i][k]);
+            }
+
+            if (nrm != 0) {
+                // Form k-th Householder vector.
+                if (QR[k][k] < 0) {
+                    nrm = -nrm;
+                }
+
+                for (var i = k; i < rowsA; i++) {
+                    QR[i][k] /= nrm;
+                }
+
+                QR[k][k] += 1;
+
+                // Apply transformation to remaining columns.
+                for (var j = k + 1; j < colsA; j++) {
+                    var s = 0;
+
+                    for (var i = k; i < rowsA; i++) {
+                        s += QR[i][k] * QR[i][j];
+                    }
+
+                    s = -s / QR[k][k];
+
+                    for (var i = k; i < rowsA; i++) {
+                        QR[i][j] += s * QR[i][k];
+                    }
+                }
+            }
+            Rdiag[k] = -nrm;
+        }
+
+        for (var j = 0; j < colsA; j++) {
+            if (Rdiag[j] === 0) {
+                throw new Error('Matrix is rank deficient');
+            }
+        }
+
+        // Copy right hand side
+        var X = new Array(rowsB);
+
+        for (var i = 0; i < rowsB; i++) {
+            X[i] = new Array(colsB);
+        }
+
+        for (var i = 0; i < rowsB; i++) {
+            for (var j = 0; j < colsB; j++) {
+                X[i][j] = B[i][j];
+            }
+        }
+
+        // Compute Y = transpose(Q)*B
+        for (var k = 0; k < colsA; k++) {
+            for (var j = 0; j < colsB; j++) {
+                var s = 0.0;
+
+                for (var i = k; i < rowsA; i++) {
+                    s += QR[i][k] * X[i][j];
+                }
+
+                s = -s / QR[k][k];
+
+                for (var i = k; i < rowsA; i++) {
+                    X[i][j] += s * QR[i][k];
+                }
+            }
+        }
+
+        // Solve R*X = Y;
+        for (var k = colsA - 1; k >= 0; k--) {
+            for (var j = 0; j < colsB; j++) {
+                X[k][j] /= Rdiag[k];
+            }
+
+            for (var i = 0; i < k; i++) {
+                for (var j = 0; j < colsB; j++) {
+                    X[i][j] -= X[k][j] * QR[i][k];
+                }
+            }
+        }
+
+        return mat.getSubMatrix(X, 0, colsA - 1, 0, colsB - 1);
+    }
+};
 
 export default mat;

--- a/src/mat.mjs
+++ b/src/mat.mjs
@@ -175,7 +175,7 @@ const mat = {
     },
 
     /**
-     * Linear algebraic matrix addition, X = A * B
+     * Linear algebraic matrix addition, X = A + B
      * @param {Array.<Array.<Number>>} A
      * @param {Array.<Array.<Number>>} B
      * @return {Array.<Array.<Number>>} A + B

--- a/src/mat.mjs
+++ b/src/mat.mjs
@@ -230,7 +230,7 @@ const mat = {
      * @return {Array.<Array.<Number>>}  solution if A is square, least squares solution otherwiseis
      */
     solve(A, B) {
-        if (A.length === A[0].lenth) {
+        if (A.length === A[0].length) {
             // A is square
             return mat.LUDecomposition(A, B);
         }

--- a/src/ridgeRegThreaded.mjs
+++ b/src/ridgeRegThreaded.mjs
@@ -1,5 +1,5 @@
 import util from './util';
-import numeric from 'numeric';
+import mat from './mat';
 import util_regression from './util_regression';
 import params from './params';
 
@@ -24,60 +24,60 @@ reg.RidgeRegThreaded = function() {
 /**
  * Initialize new arrays and initialize Kalman filter.
  */
-reg.RidgeRegThreaded.prototype.init = function() { 
-    this.screenXClicksArray = new util.DataWindow(dataWindow);  
-    this.screenYClicksArray = new util.DataWindow(dataWindow);  
-    this.eyeFeaturesClicks = new util.DataWindow(dataWindow);   
+reg.RidgeRegThreaded.prototype.init = function() {
+    this.screenXClicksArray = new util.DataWindow(dataWindow);
+    this.screenYClicksArray = new util.DataWindow(dataWindow);
+    this.eyeFeaturesClicks = new util.DataWindow(dataWindow);
 
-    this.screenXTrailArray = new util.DataWindow(trailDataWindow);  
-    this.screenYTrailArray = new util.DataWindow(trailDataWindow);  
-    this.eyeFeaturesTrail = new util.DataWindow(trailDataWindow);   
+    this.screenXTrailArray = new util.DataWindow(trailDataWindow);
+    this.screenYTrailArray = new util.DataWindow(trailDataWindow);
+    this.eyeFeaturesTrail = new util.DataWindow(trailDataWindow);
 
-    this.dataClicks = new util.DataWindow(dataWindow);  
-    this.dataTrail = new util.DataWindow(dataWindow);   
+    this.dataClicks = new util.DataWindow(dataWindow);
+    this.dataTrail = new util.DataWindow(dataWindow);
 
-    // Place the src/ridgeworker.js file into the same directory as your html file. 
-    if (!this.worker) { 
-        this.worker = new Worker('ridgeWorker.mjs'); // [20200708] TODO: Figure out how to make this inline 
-        this.worker.onerror = function(err) { console.log(err.message); };  
-        this.worker.onmessage = function(evt) { 
-            weights.X = evt.data.X; 
-            weights.Y = evt.data.Y; 
-        };  
-        console.log('initialized worker');  
-    }   
+    // Place the src/ridgeworker.js file into the same directory as your html file.
+    if (!this.worker) {
+        this.worker = new Worker('ridgeWorker.mjs'); // [20200708] TODO: Figure out how to make this inline
+        this.worker.onerror = function(err) { console.log(err.message); };
+        this.worker.onmessage = function(evt) {
+            weights.X = evt.data.X;
+            weights.Y = evt.data.Y;
+        };
+        console.log('initialized worker');
+    }
 
-    // Initialize Kalman filter [20200608 xk] what do we do about parameters?   
-    // [20200611 xk] unsure what to do w.r.t. dimensionality of these matrices. So far at least 
-    //               by my own anecdotal observation a 4x1 x vector seems to work alright   
-    var F = [ [1, 0, 1, 0], 
-              [0, 1, 0, 1], 
-              [0, 0, 1, 0], 
-              [0, 0, 0, 1]];    
+    // Initialize Kalman filter [20200608 xk] what do we do about parameters?
+    // [20200611 xk] unsure what to do w.r.t. dimensionality of these matrices. So far at least
+    //               by my own anecdotal observation a 4x1 x vector seems to work alright
+    var F = [ [1, 0, 1, 0],
+              [0, 1, 0, 1],
+              [0, 0, 1, 0],
+              [0, 0, 0, 1]];
 
-    //Parameters Q and R may require some fine tuning   
-    var Q = [ [1/4, 0,    1/2, 0],  
-              [0,   1/4,  0,   1/2],    
-              [1/2, 0,    1,   0],  
-              [0,  1/2,  0,   1]];// * delta_t  
-    var delta_t = 1/10; // The amount of time between frames    
-    Q = numeric.mul(Q, delta_t);    
+    //Parameters Q and R may require some fine tuning
+    var Q = [ [1/4, 0,    1/2, 0],
+              [0,   1/4,  0,   1/2],
+              [1/2, 0,    1,   0],
+              [0,  1/2,  0,   1]];// * delta_t
+    var delta_t = 1/10; // The amount of time between frames
+    Q = mat.multScalar(Q, delta_t);
 
-    var H = [ [1, 0, 0, 0, 0, 0],   
-              [0, 1, 0, 0, 0, 0],   
-              [0, 0, 1, 0, 0, 0],   
-              [0, 0, 0, 1, 0, 0]];  
-    var H = [ [1, 0, 0, 0], 
-              [0, 1, 0, 0]];    
-    var pixel_error = 47; //We will need to fine tune this value [20200611 xk] I just put a random value here   
+    var H = [ [1, 0, 0, 0, 0, 0],
+              [0, 1, 0, 0, 0, 0],
+              [0, 0, 1, 0, 0, 0],
+              [0, 0, 0, 1, 0, 0]];
+    var H = [ [1, 0, 0, 0],
+              [0, 1, 0, 0]];
+    var pixel_error = 47; //We will need to fine tune this value [20200611 xk] I just put a random value here
 
-    //This matrix represents the expected measurement error 
-    var R = numeric.mul(numeric.identity(2), pixel_error);  
+    //This matrix represents the expected measurement error
+    var R = mat.multScalar(mat.identity(2), pixel_error);
 
-    var P_initial = numeric.mul(numeric.identity(4), 0.0001); //Initial covariance matrix   
-    var x_initial = [[500], [500], [0], [0]]; // Initial measurement matrix 
+    var P_initial = mat.multScalar(mat.identity(4), 0.0001); //Initial covariance matrix
+    var x_initial = [[500], [500], [0], [0]]; // Initial measurement matrix
 
-    this.kalman = new util_regression.KalmanFilter(F, H, Q, R, P_initial, x_initial);  
+    this.kalman = new util_regression.KalmanFilter(F, H, Q, R, P_initial, x_initial);
 }
 /**
  * Add given data from eyes

--- a/src/util.mjs
+++ b/src/util.mjs
@@ -1,6 +1,5 @@
 import mat from './mat';
 import params from './params';
-import numeric from 'numeric';
 
 const util = {};
 
@@ -33,7 +32,7 @@ util.Eye = function(patch, imagex, imagey, width, height) {
 util.getEyeFeats = function(eyes) {
     var resizedLeft = this.resizeEye(eyes.left, resizeWidth, resizeHeight);
     var resizedRight = this.resizeEye(eyes.right, resizeWidth, resizeHeight);
-    
+
     var leftGray = this.grayscale(resizedLeft.data, resizedLeft.width, resizedLeft.height);
     var rightGray = this.grayscale(resizedRight.data, resizedRight.width, resizedRight.height);
 

--- a/src/util_regression.mjs
+++ b/src/util_regression.mjs
@@ -111,11 +111,6 @@ util_regression.KalmanFilter.prototype.update = function(z) {
     // kalman multiplier: K = P * H' * (H * P * H' + R)^-1
     var K = mult(P_p, mult(transpose(this.H), inv(S))); //This is the Optimal Kalman Gain
 
-    //We need to change Y into it's column vector form
-    for(var i = 0; i < y.length; i++){
-        y[i] = [y[i]];
-    }
-
     //Now we correct the internal values of the model
     // correction: X = X + K * (m - H * X)  |  P = (I - K * H) * P
     this.X = add(X_p, mult(K, y));

--- a/src/worker_scripts/mat.js
+++ b/src/worker_scripts/mat.js
@@ -1,306 +1,484 @@
 (function() {
     'use strict';
 
+    /**
+     * Matrix operations, mostly based on WEKA
+     * @see https://github.com/Waikato/weka-3.8/blob/master/weka/src/main/java/weka/core/matrix/Matrix.java
+     */
+
+    /**
+     * @callback operationCallback
+     * @param {number} a - an element of matrix A
+     * @param {number} b - an element of matrix B
+     * @return {number} a ○ b
+     */
+    /**
+     * Apply arithmetic operations to every element of A and B:
+     * X = A ○ B, where ○ can be one of +, -, *, /, etc.
+     *
+     * @param {Array.<Array.<Number>>} A
+     * @param {Array.<Array.<Number>>} B
+     * @param {operationCallback} op - operation to apply, op(a, b) => a ○ b
+     * @return {Array.<Array.<Number>>} A ○ B
+     */
+    function applyArithmeticOperation(A, B, op) {
+        if (A.length !== B.length || A[0].length !== B[0].length) {
+            throw new Error('Matrix dimensions must agree.');
+        }
+
+        const rows = A.length;
+        const cols = A[0].length;
+
+        const X = new Array(rows);
+
+        for (let i = 0; i < rows; i++) {
+            X[i] = new Array(cols);
+
+            for (let j = 0; j < cols; j++) {
+                X[i][j] = op(A[i][j], B[i][j]);
+            }
+        }
+
+        return X;
+    }
+
+    const mat = {
+        /**
+         * Transposes an m*n array
+         * @param {Array.<Array.<Number>>} matrix - of 'M x N' dimensionality
+         * @return {Array.<Array.<Number>>} transposed matrix
+         */
+        transpose(matrix) {
+            const rows = matrix.length;
+            const cols = matrix[0].length;
+            const transposedMatrix = new Array(cols);
+
+            for (let j = 0; j < cols; j++) {
+                transposedMatrix[j] = new Array(rows);
+
+                for (let i = 0; i < rows; i++) {
+                    transposedMatrix[j][i] = matrix[i][j];
+                }
+            }
+
+            return transposedMatrix;
+        },
+
+        /**
+         * Get a sub-matrix of matrix
+         * @param {Array.<Array.<Number>>} matrix - original matrix
+         * @param {Array.<Number>} r - Array of row indices
+         * @param {Number} j0 - Initial column index
+         * @param {Number} j1 - Final column index
+         * @returns {Array} The sub-matrix matrix(r(:),j0:j1)
+         */
+        getMatrix(matrix, r, j0, j1) {
+            const X = new Array(r.length);
+            const m = j1 - j0 + 1;
+
+            for (let i = 0, len = r.length; i < len; i++) {
+                X[i] = new Array(m);
+
+                for (let j = j0; j <= j1; j++) {
+                    X[i][j - j0] = matrix[r[i]][j];
+                }
+            }
+
+            return X;
+        },
+
+        /**
+         * Get a submatrix of matrix
+         * @param {Array.<Array.<Number>>} matrix - original matrix
+         * @param {Number} i0 - Initial row index
+         * @param {Number} i1 - Final row index
+         * @param {Number} j0 - Initial column index
+         * @param {Number} j1 - Final column index
+         * @return {Array} The sub-matrix matrix(i0:i1,j0:j1)
+         */
+        getSubMatrix(matrix, i0, i1, j0, j1) {
+            const size = j1 - j0 + 1;
+            const X = new Array(i1 - i0 + 1);
+
+            for (let i = i0; i <= i1; i++) {
+                const subI = i - i0;
+                X[subI] = new Array(size);
+
+                for (let j = j0; j <= j1; j++) {
+                    X[subI][j - j0] = matrix[i][j];
+                }
+            }
+
+            return X;
+        },
+
+        /**
+         * Linear algebraic matrix multiplication, X = A * B
+         * @param {Array.<Array.<Number>>} A
+         * @param {Array.<Array.<Number>>} B
+         * @return {Array.<Array.<Number>>} Matrix product, A * B
+         */
+        mult(A, B) {
+            // matrices shape
+            const rowsA = A.length, colsA = A[0].length;
+            const rowsB = B.length, colsB = B[0].length;
+
+            if (colsA !== rowsB) {
+                throw new Error('Matrix inner dimensions must agree.');
+            }
+
+            const X = new Array(rowsA);
+            const Bcolj = new Array(colsA);
+
+            for (let j = 0; j < colsB; j++) {
+                for (let k = 0; k < colsA; k++) {
+                    Bcolj[k] = B[k][j];
+                }
+
+                for (let i = 0; i < rowsA; i++) {
+                    if (j === 0) {
+                        X[i] = new Array(colsB);
+                    }
+
+                    const Arowi = A[i];
+                    let s = 0;
+
+                    for (let k = 0; k < colsA; k++) {
+                        s += Arowi[k] * Bcolj[k];
+                    }
+
+                    X[i][j] = s;
+                }
+            }
+
+            return X;
+        },
+
+        /**
+         * Multiply a matrix by a scalar, X = s*A
+         * @param {Array.<Array.<Number>>}  A - matrix
+         * @param {Number}                  s - scalar
+         * @return {Array.<Array.<Number>>} s*A
+         */
+        multScalar(A, s) {
+            const rows = A.length;
+            const cols = A[0].length;
+
+            const X = new Array(rows);
+
+            for (let i = 0; i < rows; i++) {
+                X[i] = new Array(cols);
+
+                for (let j = 0; j < cols; j++) {
+                    X[i][j] = A[i][j] * s;
+                }
+            }
+
+            return X;
+        },
+
+        /**
+         * Linear algebraic matrix addition, X = A * B
+         * @param {Array.<Array.<Number>>} A
+         * @param {Array.<Array.<Number>>} B
+         * @return {Array.<Array.<Number>>} A + B
+         */
+        add(A, B) {
+            return applyArithmeticOperation(A, B, (a, b) => a + b);
+        },
+
+        /**
+         * Linear algebraic matrix subtraction, X = A - B
+         * @param {Array.<Array.<Number>>} A
+         * @param {Array.<Array.<Number>>} B
+         * @return {Array.<Array.<Number>>} A - B
+         */
+        sub(A, B) {
+            return applyArithmeticOperation(A, B, (a, b) => a - b);
+        },
+
+        /**
+         * Matrix inverse or pseudoinverse, based on WEKA code
+         * @param {Array.<Array.<Number>>} A - original matrix
+         * @return inverse(A) if A is square, pseudoinverse otherwise.
+         */
+        inv(A) {
+            return mat.solve(A, mat.identity(A.length, A[0].length));
+        },
+
+        /**
+         * Generate identity matrix, based on WEKA code
+         * @param {Number} m - number of rows.
+         * @param {Number} [n] - number of colums, n = m if undefined.
+         * @return {Array.<Array.<Number>>} An m * n matrix with ones on the diagonal and zeros elsewhere.
+         */
+        identity(m, n = m) {
+            const X = new Array(m);
+
+            for (let i = 0; i < m; i++) {
+                X[i] = new Array(n);
+
+                for (let j = 0; j < n; j++) {
+                    X[i][j] = (i === j ? 1.0 : 0.0);
+                }
+            }
+
+            return X;
+        },
+
+        /**
+         * Solve A*X = B, based on WEKA code
+         * @param {Array.<Array.<Number>>} A - left matrix of equation to be solved
+         * @param {Array.<Array.<Number>>} B - right matrix of equation to be solved
+         * @return {Array.<Array.<Number>>}  solution if A is square, least squares solution otherwiseis
+         */
+        solve(A, B) {
+            if (A.length === A[0].lenth) {
+                // A is square
+                return mat.LUDecomposition(A, B);
+            }
+
+            return mat.QRDecomposition(A, B);
+        },
+
+        /**
+         * LUDecomposition to solve A*X = B, based on WEKA code
+         * @param {Array.<Array.<Number>>} A - left matrix of equation to be solved
+         * @param {Array.<Array.<Number>>} B - right matrix of equation to be solved
+         * @return {Array.<Array.<Number>>} X so that L*U*X = B(piv,:)
+         */
+        LUDecomposition(A, B) {
+            // matrices shape
+            const rowsA = A.length, colsA = A[0].length;
+            const rowsB = B.length, colsB = B[0].length;
+
+            if (rowsA !== rowsB) {
+                throw new Error('Matrix row dimensions must agree.');
+            }
+
+            var LU = new Array(rowsA);
+
+            for (var i = 0; i < rowsA; i++) {
+                LU[i] = new Array(colsA);
+                for (var j = 0; j < colsA; j++) {
+                    LU[i][j] = A[i][j];
+                }
+            }
+
+            var piv = new Array(rowsA);
+
+            for (var i = 0; i < rowsA; i++) {
+                piv[i] = i;
+            }
+
+            var pivsign = 1;
+            var LUrowi = new Array();
+            var LUcolj = new Array(rowsA);
+
+            // Outer loop.
+            for (var j = 0; j < colsA; j++) {
+                // Make a copy of the j-th column to localize references.
+                for (var i = 0; i < rowsA; i++) {
+                    LUcolj[i] = LU[i][j];
+                }
+
+                // Apply previous transformations.
+                for (var i = 0; i < rowsA; i++) {
+                    LUrowi = LU[i];
+                    // Most of the time is spent in the following dot product.
+                    var kmax = Math.min(i, j);
+                    var s = 0;
+
+                    for (var k = 0; k < kmax; k++) {
+                        s += LUrowi[k] * LUcolj[k];
+                    }
+
+                    LUrowi[j] = LUcolj[i] -= s;
+                }
+
+                // Find pivot and exchange if necessary.
+                var p = j;
+
+                for (var i = j + 1; i < rowsA; i++) {
+                    if (Math.abs(LUcolj[i]) > Math.abs(LUcolj[p])) {
+                        p = i;
+                    }
+                }
+
+                if (p != j) {
+                    for (var k = 0; k < colsA; k++) {
+                        var t = LU[p][k];
+                        LU[p][k] = LU[j][k];
+                        LU[j][k] = t;
+                    }
+
+                    var k = piv[p];
+                    piv[p] = piv[j];
+                    piv[j] = k;
+                    pivsign = -pivsign;
+                }
+
+                // Compute multipliers.
+                if (j < rowsA & LU[j][j] != 0) {
+                    for (var i = j + 1; i < rowsA; i++) {
+                        LU[i][j] /= LU[j][j];
+                    }
+                }
+            }
+
+            for (var j = 0; j < colsA; j++) {
+                if (LU[j][j] === 0) {
+                    throw new Error('Matrix is singular.')
+                }
+            }
+
+            var X = mat.getMatrix(B, piv, 0, colsB - 1);
+
+            // Solve L*Y = B(piv,:)
+            for (var k = 0; k < colsA; k++) {
+                for (var i = k + 1; i < colsA; i++) {
+                    for (var j = 0; j < colsB; j++) {
+                        X[i][j] -= X[k][j] * LU[i][k];
+                    }
+                }
+            }
+
+            // Solve U*X = Y;
+            for (var k = colsA - 1; k >= 0; k--) {
+                for (var j = 0; j < colsB; j++) {
+                    X[k][j] /= LU[k][k];
+                }
+
+                for (var i = 0; i < k; i++) {
+                    for (var j = 0; j < colsB; j++) {
+                        X[i][j] -= X[k][j] * LU[i][k];
+                    }
+                }
+            }
+
+            return X;
+        },
+
+        /**
+         * Least squares solution of A*X = B, based on WEKA code
+         * @param {Array.<Array.<Number>>} A - left side matrix to be solved
+         * @param {Array.<Array.<Number>>} B - a matrix with as many rows as A and any number of columns.
+         * @return {Array.<Array.<Number>>} X - that minimizes the two norms of QR*X-B.
+         */
+        QRDecomposition(A, B) {
+            // matrices shape
+            const rowsA = A.length, colsA = A[0].length;
+            const rowsB = B.length, colsB = B[0].length;
+
+            if (rowsA !== rowsB) {
+                throw new Error('Matrix row dimensions must agree.');
+            }
+
+            // Initialize.
+            var QR = new Array(rowsA);
+
+            for (var i = 0; i < rowsA; i++) {
+                QR[i] = new Array(colsA);
+                for (var j = 0; j < colsA; j++) {
+                    QR[i][j] = A[i][j];
+                }
+            }
+
+            var Rdiag = new Array(colsA);
+            var nrm;
+
+            // Main loop.
+            for (var k = 0; k < colsA; k++) {
+                // Compute 2-norm of k-th column without under/overflow.
+                nrm = 0;
+
+                for (var i = k; i < rowsA; i++) {
+                    nrm = Math.hypot(nrm, QR[i][k]);
+                }
+
+                if (nrm != 0) {
+                    // Form k-th Householder vector.
+                    if (QR[k][k] < 0) {
+                        nrm = -nrm;
+                    }
+
+                    for (var i = k; i < rowsA; i++) {
+                        QR[i][k] /= nrm;
+                    }
+
+                    QR[k][k] += 1;
+
+                    // Apply transformation to remaining columns.
+                    for (var j = k + 1; j < colsA; j++) {
+                        var s = 0;
+
+                        for (var i = k; i < rowsA; i++) {
+                            s += QR[i][k] * QR[i][j];
+                        }
+
+                        s = -s / QR[k][k];
+
+                        for (var i = k; i < rowsA; i++) {
+                            QR[i][j] += s * QR[i][k];
+                        }
+                    }
+                }
+                Rdiag[k] = -nrm;
+            }
+
+            for (var j = 0; j < colsA; j++) {
+                if (Rdiag[j] === 0) {
+                    throw new Error('Matrix is rank deficient');
+                }
+            }
+
+            // Copy right hand side
+            var X = new Array(rowsB);
+
+            for (var i = 0; i < rowsB; i++) {
+                X[i] = new Array(colsB);
+            }
+
+            for (var i = 0; i < rowsB; i++) {
+                for (var j = 0; j < colsB; j++) {
+                    X[i][j] = B[i][j];
+                }
+            }
+
+            // Compute Y = transpose(Q)*B
+            for (var k = 0; k < colsA; k++) {
+                for (var j = 0; j < colsB; j++) {
+                    var s = 0.0;
+
+                    for (var i = k; i < rowsA; i++) {
+                        s += QR[i][k] * X[i][j];
+                    }
+
+                    s = -s / QR[k][k];
+
+                    for (var i = k; i < rowsA; i++) {
+                        X[i][j] += s * QR[i][k];
+                    }
+                }
+            }
+
+            // Solve R*X = Y;
+            for (var k = colsA - 1; k >= 0; k--) {
+                for (var j = 0; j < colsB; j++) {
+                    X[k][j] /= Rdiag[k];
+                }
+
+                for (var i = 0; i < k; i++) {
+                    for (var j = 0; j < colsB; j++) {
+                        X[i][j] -= X[k][j] * QR[i][k];
+                    }
+                }
+            }
+
+            return mat.getSubMatrix(X, 0, colsA - 1, 0, colsB - 1);
+        }
+    };
+
     self.webgazer = self.webgazer || {};
     self.webgazer.mat = self.webgazer.mat || {};
-
-    /**
-     * Transposes an mxn array
-     * @param {Array.<Array.<Number>>} matrix - of 'M x N' dimensionality
-     * @return {Array.<Array.<Number>>} transposed matrix
-     */
-    self.webgazer.mat.transpose = function(matrix){
-        var m = matrix.length;
-        var n = matrix[0].length;
-        var transposedMatrix = new Array(n);
-
-        for (var i = 0; i < m; i++){
-            for (var j = 0; j < n; j++){
-                if (i === 0) transposedMatrix[j] = new Array(m);
-                transposedMatrix[j][i] = matrix[i][j];
-            }
-        }
-
-        return transposedMatrix;
-    };
-
-    /**
-     * Get a sub-matrix of matrix
-     * @param {Array.<Array.<Number>>} matrix - original matrix
-     * @param {Array.<Number>} r - Array of row indices
-     * @param {Number} j0 - Initial column index
-     * @param {Number} j1 - Final column index
-     * @returns {Array} The sub-matrix matrix(r(:),j0:j1)
-     */
-    self.webgazer.mat.getMatrix = function(matrix, r, j0, j1){
-        var X = new Array(r.length),
-            m = j1-j0+1;
-
-        for (var i = 0; i < r.length; i++){
-            X[i] = new Array(m);
-            for (var j = j0; j <= j1; j++){
-                X[i][j-j0] = matrix[r[i]][j];
-            }
-        }
-        return X;
-    };
-
-    /**
-     * Get a submatrix of matrix
-     * @param {Array.<Array.<Number>>} matrix - original matrix
-     * @param {Number} i0 - Initial row index
-     * @param {Number} i1 - Final row index
-     * @param {Number} j0 - Initial column index
-     * @param {Number} j1 - Final column index
-     * @return {Array} The sub-matrix matrix(i0:i1,j0:j1)
-     */
-    self.webgazer.mat.getSubMatrix = function(matrix, i0, i1, j0, j1){
-        var size = j1 - j0 + 1,
-            X = new Array(i1-i0+1);
-
-        for (var i = i0; i <= i1; i++){
-            var subI = i-i0;
-
-            X[subI] = new Array(size);
-
-            for (var j = j0; j <= j1; j++){
-                X[subI][j-j0] = matrix[i][j];
-            }
-        }
-        return X;
-    };
-
-    /**
-     * Linear algebraic matrix multiplication, matrix1 * matrix2
-     * @param {Array.<Array.<Number>>} matrix1
-     * @param {Array.<Array.<Number>>} matrix2
-     * @return {Array.<Array.<Number>>} Matrix product, matrix1 * matrix2
-     */
-    self.webgazer.mat.mult = function(matrix1, matrix2){
-
-        if (matrix2.length != matrix1[0].length){
-            console.log('Matrix inner dimensions must agree:');
-            
-        }
-
-        var X = new Array(matrix1.length),
-            Bcolj = new Array(matrix1[0].length);
-
-        for (var j = 0; j < matrix2[0].length; j++){
-            for (var k = 0; k < matrix1[0].length; k++){
-                Bcolj[k] = matrix2[k][j];
-            }
-            for (var i = 0; i < matrix1.length; i++){
-
-                if (j === 0)
-                    X[i] = new Array(matrix2[0].length);
-
-                var Arowi = matrix1[i];
-                var s = 0;
-                for (var k = 0; k < matrix1[0].length; k++){
-                    s += Arowi[k]*Bcolj[k];
-                }
-                X[i][j] = s;
-            }
-        }
-        return X;
-    };
-
-
-    /**
-     * LUDecomposition to solve A*X = B, based on WEKA code
-     * @param {Array.<Array.<Number>>} A - left matrix of equation to be solved
-     * @param {Array.<Array.<Number>>} B - right matrix of equation to be solved
-     * @return {Array.<Array.<Number>>} X so that L*U*X = B(piv,:)
-     */
-    self.webgazer.mat.LUDecomposition = function(A,B){
-        var LU = new Array(A.length);
-
-        for (var i = 0; i < A.length; i++){
-          LU[i] = new Array(A[0].length);
-            for (var j = 0; j < A[0].length; j++){
-                LU[i][j] = A[i][j];
-            }
-        }
-
-        var m = A.length;
-        var n = A[0].length;
-        var piv = new Array(m);
-        for (var i = 0; i < m; i++){
-            piv[i] = i;
-        }
-        var pivsign = 1;
-        var LUrowi = new Array();
-        var LUcolj = new Array(m);
-        // Outer loop.
-        for (var j = 0; j < n; j++){
-            // Make a copy of the j-th column to localize references.
-            for (var i = 0; i < m; i++){
-                LUcolj[i] = LU[i][j];
-            }
-            // Apply previous transformations.
-            for (var i = 0; i < m; i++){
-                LUrowi = LU[i];
-                // Most of the time is spent in the following dot product.
-                var kmax = Math.min(i,j);
-                var s = 0;
-                for (var k = 0; k < kmax; k++){
-                    s += LUrowi[k]*LUcolj[k];
-                }
-                LUrowi[j] = LUcolj[i] -= s;
-            }
-            // Find pivot and exchange if necessary.
-            var p = j;
-            for (var i = j+1; i < m; i++){
-                if (Math.abs(LUcolj[i]) > Math.abs(LUcolj[p])){
-                    p = i;
-                }
-            }
-            if (p != j){
-                for (var k = 0; k < n; k++){
-                    var t = LU[p][k];
-                    LU[p][k] = LU[j][k];
-                    LU[j][k] = t;
-                }
-                var k = piv[p];
-                piv[p] = piv[j];
-                piv[j] = k;
-                pivsign = -pivsign;
-            }
-            // Compute multipliers.
-            if (j < m & LU[j][j] != 0){
-                for (var i = j+1; i < m; i++){
-                    LU[i][j] /= LU[j][j];
-                }
-            }
-        }
-        if (B.length != m){
-            console.log('Matrix row dimensions must agree.');
-        }
-        for (var j = 0; j < n; j++){
-            if (LU[j][j] === 0){
-                console.log('Matrix is singular.')
-            }
-        }
-        var nx = B[0].length;
-        var X = self.webgazer.mat.getMatrix(B,piv,0,nx-1);
-        // Solve L*Y = B(piv,:)
-        for (var k = 0; k < n; k++){
-            for (var i = k+1; i < n; i++){
-                for (var j = 0; j < nx; j++){
-                    X[i][j] -= X[k][j]*LU[i][k];
-                }
-            }
-        }
-        // Solve U*X = Y;
-        for (var k = n-1; k >= 0; k--){
-            for (var j = 0; j < nx; j++){
-                X[k][j] /= LU[k][k];
-            }
-            for (var i = 0; i < k; i++){
-                for (var j = 0; j < nx; j++){
-                    X[i][j] -= X[k][j]*LU[i][k];
-                }
-            }
-        }
-        return X;
-    };
-
-    /**
-     * Least squares solution of A*X = B, based on WEKA code
-     * @param {Array.<Array.<Number>>} A - left side matrix to be solved
-     * @param {Array.<Array.<Number>>} B - a matrix with as many rows as A and any number of columns.
-     * @return {Array.<Array.<Number>>} X - that minimizes the two norms of QR*X-B.
-     */
-    self.webgazer.mat.QRDecomposition = function(A, B){
-        // Initialize.
-        var QR = new Array(A.length);
-
-        for (var i = 0; i < A.length; i++){
-            QR[i] = new Array(A[0].length);
-            for (var j = 0; j < A[0].length; j++){
-                QR[i][j] = A[i][j];
-            }
-        }
-        var m = A.length;
-        var n = A[0].length;
-        var Rdiag = new Array(n);
-        var nrm;
-
-        // Main loop.
-        for (var k = 0; k < n; k++){
-            // Compute 2-norm of k-th column without under/overflow.
-            nrm = 0;
-            for (var i = k; i < m; i++){
-                nrm = Math.hypot(nrm,QR[i][k]);
-            }
-            if (nrm != 0){
-                // Form k-th Householder vector.
-                if (QR[k][k] < 0){
-                    nrm = -nrm;
-                }
-                for (var i = k; i < m; i++){
-                    QR[i][k] /= nrm;
-                }
-                QR[k][k] += 1;
-
-                // Apply transformation to remaining columns.
-                for (var j = k+1; j < n; j++){
-                    var s = 0;
-                    for (var i = k; i < m; i++){
-                        s += QR[i][k]*QR[i][j];
-                    }
-                    s = -s/QR[k][k];
-                    for (var i = k; i < m; i++){
-                        QR[i][j] += s*QR[i][k];
-                    }
-                }
-            }
-            Rdiag[k] = -nrm;
-        }
-        if (B.length != m){
-            console.log('Matrix row dimensions must agree.');
-        }
-        for (var j = 0; j < n; j++){
-            if (Rdiag[j] === 0)
-                console.log('Matrix is rank deficient');
-        }
-        // Copy right hand side
-        var nx = B[0].length;
-        var X = new Array(B.length);
-        for(var i=0; i<B.length; i++){
-            X[i] = new Array(B[0].length);
-        }
-        for (var i = 0; i < B.length; i++){
-            for (var j = 0; j < B[0].length; j++){
-                X[i][j] = B[i][j];
-            }
-        }
-        // Compute Y = transpose(Q)*B
-        for (var k = 0; k < n; k++){
-            for (var j = 0; j < nx; j++){
-                var s = 0.0;
-                for (var i = k; i < m; i++){
-                    s += QR[i][k]*X[i][j];
-                }
-                s = -s/QR[k][k];
-                for (var i = k; i < m; i++){
-                    X[i][j] += s*QR[i][k];
-                }
-            }
-        }
-        // Solve R*X = Y;
-        for (var k = n-1; k >= 0; k--){
-            for (var j = 0; j < nx; j++){
-                X[k][j] /= Rdiag[k];
-            }
-            for (var i = 0; i < k; i++){
-                for (var j = 0; j < nx; j++){
-                    X[i][j] -= X[k][j]*QR[i][k];
-                }
-            }
-        }
-        return self.webgazer.mat.getSubMatrix(X,0,n-1,0,nx-1);
-    }
-    
 }());

--- a/src/worker_scripts/util.js
+++ b/src/worker_scripts/util.js
@@ -95,10 +95,10 @@
     //Helper functions
     /**
      * Grayscales an image patch. Can be used for the whole canvas, detected face, detected eye, etc.
-     * 
+     *
      * Code from tracking.js by Eduardo Lundgren, et al.
      * https://github.com/eduardolundgren/tracking.js/blob/master/src/tracking.js
-     * 
+     *
      * Software License Agreement (BSD License) Copyright (c) 2014, Eduardo A. Lundgren Melo. All rights reserved.
      * Redistribution and use of this software in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
      * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
@@ -108,7 +108,7 @@
      * IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
      * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
      * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-     * 
+     *
      * @param  {Array} pixels - image data to be grayscaled
      * @param  {Number} width  - width of image data to be grayscaled
      * @param  {Number} height - height of image data to be grayscaled
@@ -122,7 +122,7 @@
             for (var j = 0; j < width; j++) {
                 var value = pixels[w] * 0.299 + pixels[w + 1] * 0.587 + pixels[w + 2] * 0.114;
                 gray[p++] = value;
-        
+
                 w += 4;
             }
         }
@@ -131,10 +131,10 @@
 
     /**
      * Increase contrast of an image.
-     * 
+     *
      * Code from Martin Tschirsich, Copyright (c) 2012.
      * https://github.com/mtschirs/js-objectdetect/blob/gh-pages/js/objectdetect.js
-     * 
+     *
      * @param {Array} src - grayscale integer array
      * @param {Number} step - sampling rate, control performance
      * @param {Array} dst - array to hold the resulting image
@@ -143,7 +143,7 @@
         var srcLength = src.length;
         if (!dst) dst = src;
         if (!step) step = 5;
-        
+
         // Compute histogram and histogram sum:
         var hist = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -160,11 +160,11 @@
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                     0, 0, 0, 0];
-        
+
         for (var i = 0; i < srcLength; i += step) {
             ++hist[src[i]];
         }
-        
+
         // Compute integral histogram:
         var norm = 255 * step / srcLength,
             prev = 0;
@@ -173,7 +173,7 @@
             prev = h += prev;
             hist[i] = h * norm; // For non-integer src: ~~(h * norm + 0.5);
         }
-        
+
         // Equalize image:
         for (var i = 0; i < srcLength; ++i) {
             dst[i] = hist[src[i]];
@@ -368,8 +368,9 @@
     self.webgazer.util.KalmanFilter.prototype.update = function(z) {
 
       // Here, we define all the different matrix operations we will need
-      var add = numeric.add, sub = numeric.sub, inv = numeric.inv, identity = numeric.identity;
-      var mult = webgazer.mat.mult, transpose = webgazer.mat.transpose;
+      const {
+          add, sub, mult, inv, identity, transpose,
+      } = mat;
       //TODO cache variables like the transpose of H
 
       // prediction: X = F * X  |  P = F * P * F' + Q
@@ -377,6 +378,8 @@
       var P_p = add(mult(mult(this.F,this.P), transpose(this.F)), this.Q); //Predicted covaraince
 
       //Calculate the update values
+      // transform measurement (row vector) into a column vector
+      z = transpose([z])
       var y = sub(z, mult(this.H, X_p)); // This is the measurement error (between what we expect and the actual value)
       var S = add(mult(mult(this.H, P_p), transpose(this.H)), this.R); //This is the residual covariance (the error in the covariance)
 

--- a/src/worker_scripts/util.js
+++ b/src/worker_scripts/util.js
@@ -386,11 +386,6 @@
       // kalman multiplier: K = P * H' * (H * P * H' + R)^-1
       var K = mult(P_p, mult(transpose(this.H), inv(S))); //This is the Optimal Kalman Gain
 
-      //We need to change Y into it's column vector form
-      for(var i = 0; i < y.length; i++){
-        y[i] = [y[i]];
-      }
-
       //Now we correct the internal values of the model
       // correction: X = X + K * (m - H * X)  |  P = (I - K * H) * P
       this.X = add(X_p, mult(K, y));


### PR DESCRIPTION
Resolves #211.

As is discussed in #225, the performance of `math.js` is incredibly low so we need to implement all the required matrix operations ourselves. This PR removed `numeric` completely and added matrix operations such as addition, subtraction, inversion, identity matrix generation, etc., into `mat.mjs`. Most of the implements are based on [WEKA](https://github.com/Waikato/weka-3.8/blob/master/weka/src/main/java/weka/core/matrix/Matrix.java).

CC @Skylion007 