### PR TITLE
Fix @tensorflow-models/facemesh imports

### DIFF
--- a/src/facemesh.mjs
+++ b/src/facemesh.mjs
@@ -1,4 +1,4 @@
-import FacemeshModel from '@tensorflow-models/facemesh';
+import * as FacemeshModel from '@tensorflow-models/facemesh';
 /**
  * Constructor of TFFaceMesh object
  * @constructor

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,7 @@ function createConfig(options) {
       rules: [
         {
           test: /\.mjs$/,
-          type: 'javascript/esm',
+          type: 'javascript/auto',
           exclude: /node_modules/
         }
       ]


### PR DESCRIPTION
Resolves #223, resolves #172, and maybe #183

Well, this has been annoying since I (and everyone who uses modern build systems) have to use `import webgazer from 'webgazer/dist/webgazer.commonjs2'` instead of `import webgazer from 'webgazer'`. The import statement in `src/facemesh.mjs` was not correct, because [that module does not have a default export](https://github.com/tensorflow/tfjs-models/blob/master/facemesh/src/index.ts).