### PR TITLE
fix error in removing the video container children on end

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -704,8 +704,7 @@ webgazer.end = function() {
   //webgazer.stopVideo(); // uncomment if you want to stop the video from streaming
 
   //remove video element and canvas
-  document.body.removeChild(videoElement);
-  document.body.removeChild(videoElementCanvas);
+  videoContainerElement.remove();
 
   return webgazer;
 };
@@ -719,10 +718,10 @@ webgazer.stopVideo = function() {
   videoStream.getTracks()[0].stop();
 
   // Removes the outline of the face
-  document.body.removeChild( faceOverlay );
+  videoContainerElement.removeChild( faceOverlay );
 
   // Removes the box around the face
-  document.body.removeChild( faceFeedbackBox );
+  videoContainerElement.removeChild( faceFeedbackBox );
 
   return webgazer;
 }


### PR DESCRIPTION
This line of code makes the `videoElement ` a child of the `videoContainerElement`:
https://github.com/brownhci/WebGazer/blob/966b1c149575871e4021bcca8a2d90760d122622/src/index.mjs#L556
And this line of code is called in` webgazer.end()`:
https://github.com/brownhci/WebGazer/blob/966b1c149575871e4021bcca8a2d90760d122622/src/index.mjs#L707
Removing the `videoElement `as if it is a child of the `document.body` is causing a JavaScript error.
Therefore, I fixed the issue in this pull-request by removing the `videoContainerElement` in `webgazer.end()` since it's created on `webgazer.begin()` and holds the `videoElement ` and the `videoElementCanvas`.