### PR TITLE
change video container width and height in setVideoViewerSize

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -920,6 +920,10 @@ webgazer.setVideoViewerSize = function(w, h) {
   videoElement.style.width = w + 'px';
   videoElement.style.height = h + 'px';
 
+  // Change video container
+  videoContainerElement.style.width = w + 'px';
+  videoContainerElement.style.height = h + 'px';
+
   // Change the face overlay
   faceOverlay.style.width = w + 'px';
   faceOverlay.style.height = h + 'px';


### PR DESCRIPTION
Hey WebGazer!

I believe this to just be a small improvement to #197. I noticed that the entire container did not update in size when setVideoViewerSize is called. 

This pull request ensures that the video container element's width and height are also updated in setVideoViewerSize. 

I thought it might be useful to have since it solved some problems that I was having. 