### PR TITLE
Configurable monocular tracking

### DIFF
--- a/src/params.mjs
+++ b/src/params.mjs
@@ -22,6 +22,8 @@ const params = {
   saveDataAcrossSessions: true,
   // Whether or not to store accuracy eigenValues, used by the calibration example file
   storingPoints: false,
+
+  trackEye: 'both',
 };
 
 export default params;

--- a/src/util.mjs
+++ b/src/util.mjs
@@ -31,22 +31,25 @@ util.Eye = function(patch, imagex, imagey, width, height) {
  * @returns {Array.<T>} The eyes gray level histogram
  */
 util.getEyeFeats = function(eyes) {
-    var resizedLeft = this.resizeEye(eyes.left, resizeWidth, resizeHeight);
-    var resizedRight = this.resizeEye(eyes.right, resizeWidth, resizeHeight);
-    
-    var leftGray = this.grayscale(resizedLeft.data, resizedLeft.width, resizedLeft.height);
-    var rightGray = this.grayscale(resizedRight.data, resizedRight.width, resizedRight.height);
+    let process = (eye) => {
+        let resized = this.resizeEye(eye, resizeWidth, resizeHeight);
+        let gray = this.grayscale(resized.data, resized.width, resized.height);
+        let hist = [];
+        this.equalizeHistogram(gray, 5, hist);
+        return hist;
+    };
 
-    var histLeft = [];
-    this.equalizeHistogram(leftGray, 5, histLeft);
-    var histRight = [];
-    this.equalizeHistogram(rightGray, 5, histRight);
-
-    var leftGrayArray = Array.prototype.slice.call(histLeft);
-    var rightGrayArray = Array.prototype.slice.call(histRight);
-
-    return histLeft.concat(histRight);
+    if (webgazer.params.trackEye == 'left') {
+        return process(eyes.left);
+    }
+    else if (webgazer.params.trackEye == 'right') {
+        return process(eyes.right);
+    }
+    else {
+        return [].concat(process(eyes.left), process(eyes.right));
+    }
 }
+
 //Data Window class
 //operates like an array but 'wraps' data around to keep the array at a fixed windowSize
 /**


### PR DESCRIPTION
I've added a `trackEye` parameter to `webgazer.params` that enables tracking a single eye instead of both.
This may be desirable in certain cases and can also improve performance on slower computers.