### PR TITLE
Adding scripts and README instruction to build and run the calibration example within Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,15 @@ To run the example files as a server:
 	# Run the webpage index.html as a server
 	npm run serve
 
+## Build and run the Example with Docker
+
+The WebGazer can be deployed locally using the provided Docker configuration:
+
+1. Build WebGazer in a Docker container: `docker build -t webgazer . -f docker/Dockerfile`
+2. Start the docker container as a service: `cd docker && docker-compose up -d`
+3. Visit the WebGazer example application at http://localhost:8080/calibration.html
+4. Stop the docker service, when you don't need it anymore: `cd docker && docker-compose down`
+
 ## Browser Support
 
 The following browsers support WebGazer.js:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:16 AS builder
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+COPY package*.json ./
+
+RUN npm install
+
+# Bundle app source
+COPY ./src ./src
+COPY ./README.md .
+COPY ./webpack.config.js .
+RUN mkdir bin
+
+RUN npm run build
+
+FROM node:16
+
+WORKDIR /usr/src/app
+COPY ./www ./www
+
+WORKDIR /usr/src/app/www
+COPY --from=builder /usr/src/app/dist/webgazer.js .
+COPY --from=builder /usr/src/app/dist/webgazer.js.map .
+RUN npm install
+
+EXPOSE 3000
+CMD ["npm", "run", "serve"]
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.7'
+
+services:
+  webgazer:
+    image: webgazer
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:3000"
+


### PR DESCRIPTION
Hello, I would like to offer a fast & easy way of WebGazer deployment based on Docker. Many of us are still foreigners to the NodeJS technology, and may be not able to quickly sort out with the installation guidelines. On the other hand, you are providing a precompiled `www/webgazer.js`. The proposed Docker environment should be the third method in between of the two above: it allows to repeat all building steps, but without getting much into details.