### PR TITLE
fix(bug): `plotting-canvas` not spanning the entire screen

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -1,44 +1,49 @@
-window.onload = async function() {
+window.onload = async function () {
+	//start the webgazer tracker
+	await webgazer
+		.setRegression('ridge') /* currently must set regression and tracker */
+		//.setTracker('clmtrackr')
+		.setGazeListener(function (data, clock) {
+			//   console.log(data); /* data is an object containing an x and y key which are the x and y prediction coordinates (no bounds limiting) */
+			//   console.log(clock); /* elapsed time in milliseconds since webgazer.begin() was called */
+		})
+		.saveDataAcrossSessions(true)
+		.begin()
+	webgazer
+		.showVideoPreview(true) /* shows all video previews */
+		.showPredictionPoints(
+			true
+		) /* shows a square every 100 milliseconds where current prediction is */
+		.applyKalmanFilter(true) /* Kalman Filter defaults to on. Can be toggled by user. */
 
-    //start the webgazer tracker
-    await webgazer.setRegression('ridge') /* currently must set regression and tracker */
-        //.setTracker('clmtrackr')
-        .setGazeListener(function(data, clock) {
-          //   console.log(data); /* data is an object containing an x and y key which are the x and y prediction coordinates (no bounds limiting) */
-          //   console.log(clock); /* elapsed time in milliseconds since webgazer.begin() was called */
-        })
-        .saveDataAcrossSessions(true)
-        .begin();
-        webgazer.showVideoPreview(true) /* shows all video previews */
-            .showPredictionPoints(true) /* shows a square every 100 milliseconds where current prediction is */
-            .applyKalmanFilter(true); /* Kalman Filter defaults to on. Can be toggled by user. */
-
-    //Set up the webgazer video feedback.
-    var setup = function() {
-
-        //Set up the main canvas. The main canvas is used to calibrate the webgazer.
-        var canvas = document.getElementById("plotting_canvas");
-        canvas.width = window.innerWidth;
-        canvas.height = window.innerHeight;
-        canvas.style.position = 'fixed';
-    };
-    setup();
-
-};
+	//Set up the webgazer video feedback.
+	var setup = function () {
+		//Set up the main canvas. The main canvas is used to calibrate the webgazer.
+		var canvas = document.getElementById('plotting_canvas')
+		canvas.width = window.innerWidth
+		canvas.height = window.innerHeight
+		canvas.style.position = 'fixed'
+		canvas.style.pointerEvents = 'none'
+		canvas.style.top = '50vh'
+		canvas.style.left = '50vw'
+		canvas.style.transform = 'translate(-50%, -50%)'
+	}
+	setup()
+}
 
 // Set to true if you want to save the data even if you reload the page.
-window.saveDataAcrossSessions = true;
+window.saveDataAcrossSessions = true
 
-window.onbeforeunload = function() {
-    webgazer.end();
+window.onbeforeunload = function () {
+	webgazer.end()
 }
 
 /**
  * Restart the calibration process by clearing the local storage and reseting the calibration point
  */
-function Restart(){
-    document.getElementById("Accuracy").innerHTML = "<a>Not yet Calibrated</a>";
-    webgazer.clearData();
-    ClearCalibration();
-    PopUpInstruction();
+function Restart() {
+	document.getElementById('Accuracy').innerHTML = '<a>Not yet Calibrated</a>'
+	webgazer.clearData()
+	ClearCalibration()
+	PopUpInstruction()
 }


### PR DESCRIPTION
Sometimes, `plotting-canvas` does not cover the entire screen. I my case, when I use `npm run serve` it will spans, but if I use `npx lite-server`, which is a local server, it somehow doesn't work. This is a fix on the `CSS` of `setup()` to guarantee it will span whole screen on every server