### PR TITLE
refactor: `plotting-canvas` spans fullscreen independently

### DIFF
--- a/www/js/main.js
+++ b/www/js/main.js
@@ -21,6 +21,9 @@ window.onload = async function() {
         canvas.width = window.innerWidth;
         canvas.height = window.innerHeight;
         canvas.style.position = 'fixed';
+        canvas.style.pointerEvents = 'none'
+        canvas.style.top = '0px'
+        canvas.style.left = '0px'
     };
     setup();
 


### PR DESCRIPTION
As discussed in PR `#326`. Turn out it was the body padding of the CSS of my website.
It might be a small addition.  I would suggest adding:
```
canvas.style.pointerEvents = 'none'
canvas.style.top = '0px'
canvas.style.left = '0px'
```
so that the `plotting-canvas` would always span independently regardless of the client's CSS files.

Also, you are absolutely correct that it shifts and unshifts the canvas. Therefore, `top` and `left` equal to `0px` would be sufficient.