### PR TITLE
initial localized script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@
 *.cpuprofile
 dist/
 node_modules/
+local_models/
 www/node_modules/
 www/data/src/WebGazerETRA2018Dataset_Release20180420/
 www/data/src/P*/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
     "dev": "webpack --progress --config webpack.config.js --mode development",
+    "localbuild": "npm run build && ./scripts/localize_build.sh",
     "build": "webpack --progress --config webpack.config.js --mode production",
     "gen_docs": "jsdoc -c jsdoc.conf.json src/*"
   },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,13 @@
+### Localized build
+
+This script downloads the TFJS models from Kaggle and replaces the URLs in the installed npm packages with local
+paths. Please note that it is currently a hacky workaround. You will need to make sure the local_models folder also exists wherever the built webgazer.js exists.
+
+
+To compile WebGazer for local use, first read and verify `localize_build.sh`, then
+
+`chmod +x ./scripts/localize_build.sh`
+
+then run
+
+`npm run localbuild`

--- a/scripts/localize_build.sh
+++ b/scripts/localize_build.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# downloads models into local_models if they don't already exist
+# then replaces tensorflow online calls with local paths in the dist
+
+
+FACEMESH_URL="https://tfhub.dev/mediapipe/tfjs-model/facemesh/1/default/1"
+IRIS_URL="https://tfhub.dev/mediapipe/tfjs-model/iris/1/default/2"
+BLAZEFACE_URL="https://tfhub.dev/tensorflow/tfjs-model/blazeface/1/default/1"
+
+FACEMESH_LOCAL_PATH="./local_models/facemesh/"
+IRIS_LOCAL_PATH="./local_models/iris/"
+BLAZEFACE_LOCAL_PATH="./local_models/blazeface/"
+
+if [ ! -d "./local_models" ]; then
+    mkdir -p ./local_models
+    mkdir -p ./local_models/facemesh
+    mkdir -p ./local_models/iris
+    mkdir -p ./local_models/blazeface
+
+    curl -L -o ./local_models/facemesh.tar.gz \
+        https://www.kaggle.com/api/v1/models/mediapipe/facemesh/tfJs/default/1/download
+    tar -xzf ./local_models/facemesh.tar.gz -C $FACEMESH_LOCAL_PATH
+    rm ./local_models/facemesh.tar.gz
+
+
+    curl -L -o ./local_models/iris.tar.gz \
+        https://www.kaggle.com/api/v1/models/mediapipe/iris/tfJs/default/2/download
+    tar -xzf ./local_models/iris.tar.gz -C $IRIS_LOCAL_PATH
+    rm ./local_models/iris.tar.gz
+
+    curl -L -o ./local_models/blazeface.tar.gz \
+        https://www.kaggle.com/api/v1/models/tensorflow/blazeface/tfJs/default/1/download
+    tar -xzf ./local_models/blazeface.tar.gz -C $BLAZEFACE_LOCAL_PATH
+    rm ./local_models/blazeface.tar.gz
+fi
+
+find ./dist/ -type f -exec sed -i \
+    -e "s#$FACEMESH_URL#$FACEMESH_LOCAL_PATH#g" \
+    -e "s#$IRIS_URL#$IRIS_LOCAL_PATH#g" \
+    -e "s#$BLAZEFACE_URL#$BLAZEFACE_LOCAL_PATH#g" {} +
+
+echo "localization finished"


### PR DESCRIPTION
Hacky script to replace URL calls in dist/ files to local downloaded models -- instructions should be in scripts/README.md

Pretty much implemented from https://github.com/UiL-OTS-labs/WebGazer/blob/master/localize.sh

Note that this won't automatically update the `www/webgazer.js` since the string replacement is done in a shell script after files are copied over in `npm run build`. For now, you have to manually copy over webgazer.js and local_models into `www/`.